### PR TITLE
EDX-7226 Add EtherNet/IP EDS to EdgeX DeviceProfile converter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/IOTechSystems/go-mod-central-ext/v4 v4.0.100
-	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.39
+	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.40
 	github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.21
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.5.0 h1:EH+bUVJNgttidWFkLLVKaQPGmkTUfQQqjOsyvMGvD6o=
 github.com/eclipse/paho.mqtt.golang v1.5.0/go.mod h1:du/2qNQVqJf/Sqs4MEL77kR8QTqANF7XU7Fk0aOTAgk=
-github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.39 h1:jlr50ugKz0H9CkY0hIiv0X6V/Dss690wetkDMGIWLms=
-github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.39/go.mod h1:SDiRrlBMtttF3Ny8M26GNWPdMbBqhenR5pbfrCBm4zM=
+github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.40 h1:wx7B5ztxWuKFdm4ts3VCA5mn1N8mmTRniFuGHgkIri0=
+github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.40/go.mod h1:SDiRrlBMtttF3Ny8M26GNWPdMbBqhenR5pbfrCBm4zM=
 github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.21 h1:s23UjhDYcboJi/IECnv8BvJhtD93GstFDvdSIU+2BrA=
 github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.21/go.mod h1:d7RWDABSeahSKsetV9/EmlsKw/zRvVsQzrAHGi48Mz8=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/pkg/profileconv/convert.go
+++ b/pkg/profileconv/convert.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 IOTech Ltd
+
+// Package profileconv defines the common contract for converting a vendor
+// source file (EDS, xlsx, DBC, vendor JSON…) into an EdgeX DeviceProfile.
+//
+// This package holds only the format-neutral ConvertFunc type. Each concrete
+// format lives in its own sub-package (e.g. profileconv/eds) and provides a
+// Convert function that satisfies ConvertFunc — so a caller can swap formats
+// without depending on any single format's package:
+//
+//	var convert profileconv.ConvertFunc = eds.Convert
+//	profile, err := convert(ctx, lc, data, nil)
+package profileconv
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+// ConvertFunc converts one source format's bytes into an EdgeX DeviceProfile.
+//
+//   - ctx     scopes the conversion for cancellation (a format that streams or
+//     calls out may honour it; a pure in-memory pass need not).
+//   - lc      receives non-fatal notes (e.g. a modular EDS whose dynamic I/O
+//     assemblies were skipped); such notes are logged, not returned.
+//   - data    is the raw source file.
+//   - options carries format-specific tuning and may be nil.
+//
+// An error is returned only for unrecoverable input (malformed file, or no
+// convertible content).
+type ConvertFunc func(ctx context.Context, lc logger.LoggingClient,
+	data []byte, options map[string]any) (dtos.DeviceProfile, errors.EdgeX)

--- a/pkg/profileconv/eds/attributes.go
+++ b/pkg/profileconv/eds/attributes.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+// EtherNet/IP device-resource attribute keys and type values, per the XRT
+// EtherNet/IP device-service spec:
+// https://docs.iotechsys.com/edge-xrt22/device-service-components/ethernet-ip-device-service-component.html
+//
+// A resource's kind is told apart by its "type" attribute (or its absence for
+// explicit messaging):
+//
+//	implicit I/O : type O2T / T2O    + offsetBytes / offsetBits / bitLength
+//	settings     : type *Settings    + assemblyID / size / includeHeader32bit
+//	explicit     : (no type)         + objClass / instID / attrID
+//
+// The spec also defines a logixTag kind (type "logixTag" + tagName / arraySize)
+// for Allen-Bradley Logix tag access. It is intentionally NOT produced here: a
+// Logix tag is defined by the PLC program, not the EDS, so it has no source in
+// an EDS file this converter reads.
+const (
+	// attribute keys
+	attrType               = "type"
+	attrOffsetBytes        = "offsetBytes"
+	attrOffsetBits         = "offsetBits"
+	attrBitLength          = "bitLength"
+	attrAssemblyID         = "assemblyID"
+	attrSize               = "size"
+	attrIncludeHeader32bit = "includeHeader32bit"
+	attrObjClass           = "objClass"
+	attrInstID             = "instID"
+	attrAttrID             = "attrID"
+
+	// type attribute values
+	typeO2T            = "O2T" // originator-to-target: written (output)
+	typeT2O            = "T2O" // target-to-originator: read (input)
+	typeO2TSettings    = "O2TSettings"
+	typeT2OSettings    = "T2OSettings"
+	typeConfigSettings = "ConfigSettings"
+)

--- a/pkg/profileconv/eds/ciptypes.go
+++ b/pkg/profileconv/eds/ciptypes.go
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+// cipValueType maps a CIP data-type code to its EdgeX profile valueType, using
+// the core-contracts constants so the spelling matches what the profile
+// validator accepts. Codes follow the ODVA CIP elementary-data-type table.
+//
+// Bit-string types (BYTE/WORD/DWORD/LWORD) map to the unsigned integer of the
+// same width, matching how XRT profiles treat them.
+//
+// Deliberately NOT in this map — valueTypeForCIP errors on all of these rather
+// than guess a valueType:
+//   - EPATH (0xDC): a CIP path, not a data point.
+//   - Time/date types (0xC0, 0xCC–0xCF, 0xD6–0xD8, 0xDB, 0xDF): rare in I/O.
+//   - STRING2 (0xD5), STRINGN (0xD9), STRINGI (0xDE): distinct string variants
+//     with 2-byte/variable-width/structured encodings. They are NOT decodable as
+//     a plain STRING, so mapping them to String would yield a profile that reads
+//     garbled data. They are rare in fixed-I/O EDS; erroring surfaces the param
+//     rather than silently producing a wrong profile.
+//   - ENGUNIT (0xDD): engineering-unit code; rare.
+//
+// Array valueTypes (Uint8Array, Uint16Array…) and Binary/Object are also absent:
+// array-ness is not carried by a scalar CIP code — it comes from the assembly
+// layout / bitLength or a logixTag's arraySize, which set the valueType there,
+// not in this table.
+var cipValueType = map[uint8]string{
+	0xC1: common.ValueTypeBool,    // BOOL
+	0xC2: common.ValueTypeInt8,    // SINT
+	0xC3: common.ValueTypeInt16,   // INT
+	0xC4: common.ValueTypeInt32,   // DINT
+	0xC5: common.ValueTypeInt64,   // LINT
+	0xC6: common.ValueTypeUint8,   // USINT
+	0xC7: common.ValueTypeUint16,  // UINT
+	0xC8: common.ValueTypeUint32,  // UDINT
+	0xC9: common.ValueTypeUint64,  // ULINT
+	0xCA: common.ValueTypeFloat32, // REAL
+	0xCB: common.ValueTypeFloat64, // LREAL
+	0xD0: common.ValueTypeString,  // STRING
+	0xDA: common.ValueTypeString,  // SHORT_STRING
+	0xD1: common.ValueTypeUint8,   // BYTE  (8-bit collection)
+	0xD2: common.ValueTypeUint16,  // WORD  (16-bit collection)
+	0xD3: common.ValueTypeUint32,  // DWORD (32-bit collection)
+	0xD4: common.ValueTypeUint64,  // LWORD (64-bit collection)
+}
+
+// valueTypeForCIP returns the EdgeX valueType for a CIP data-type code as it
+// appears in an EDS [Params] entry (decimal or "0x" hex, e.g. "0xC3" or "195").
+// It errors on an unparseable code or one with no scalar valueType (EPATH,
+// time/date types), so callers surface the offending param rather than guessing.
+func valueTypeForCIP(code string) (string, errors.EdgeX) {
+	n, err := parseCIPCode(code)
+	if err != nil {
+		return "", err
+	}
+	vt, ok := cipValueType[n]
+	if !ok {
+		return "", errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unsupported CIP data type code 0x%02X", n), nil)
+	}
+	return vt, nil
+}
+
+// parseCIPCode parses a CIP data-type code that may be written as decimal or
+// "0x"-prefixed hex, and must fit in a byte.
+func parseCIPCode(code string) (uint8, errors.EdgeX) {
+	s := strings.TrimSpace(code)
+	if s == "" {
+		return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, "empty CIP data type code", nil)
+	}
+	// base 0 lets strconv honour a "0x" prefix as hex and bare digits as decimal.
+	n, err := strconv.ParseUint(s, 0, 8)
+	if err != nil {
+		return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("invalid CIP data type code %q", code), err)
+	}
+	return uint8(n), nil
+}

--- a/pkg/profileconv/eds/ciptypes_test.go
+++ b/pkg/profileconv/eds/ciptypes_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+func TestValueTypeForCIP(t *testing.T) {
+	tests := []struct {
+		code string
+		want string
+	}{
+		{"0xC1", common.ValueTypeBool},
+		{"0xC2", common.ValueTypeInt8},
+		{"0xC3", common.ValueTypeInt16},
+		{"0xC4", common.ValueTypeInt32},
+		{"0xC5", common.ValueTypeInt64},
+		{"0xC6", common.ValueTypeUint8},
+		{"0xC7", common.ValueTypeUint16},
+		{"0xC8", common.ValueTypeUint32},
+		{"0xC9", common.ValueTypeUint64},
+		{"0xCA", common.ValueTypeFloat32},
+		{"0xCB", common.ValueTypeFloat64},
+		{"0xD0", common.ValueTypeString},
+		{"0xDA", common.ValueTypeString},
+		{"0xD1", common.ValueTypeUint8},
+		{"0xD2", common.ValueTypeUint16},
+		{"0xD3", common.ValueTypeUint32},
+		{"0xD4", common.ValueTypeUint64},
+		// Same code in decimal and lower-case hex must resolve identically.
+		{"195", common.ValueTypeInt16}, // 0xC3
+		{"0xc3", common.ValueTypeInt16},
+	}
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			got, err := valueTypeForCIP(tt.code)
+			if err != nil {
+				t.Fatalf("valueTypeForCIP(%q): %v", tt.code, err)
+			}
+			if got != tt.want {
+				t.Errorf("valueTypeForCIP(%q): got %q, want %q", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValueTypeForCIPUnsupported(t *testing.T) {
+	// Unsupported codes must error rather than silently produce a wrong
+	// valueType: EPATH (0xDC), a time type (0xC0), and — importantly — the
+	// string variants STRING2/STRINGN/STRINGI (0xD5/0xD9/0xDE), which are NOT
+	// mapped to String because their encodings differ. Plus bad literals.
+	for _, code := range []string{"0xDC", "0xC0", "0xD5", "0xD9", "0xDE", "0xDD", "0xFF", "", "nothex"} {
+		t.Run(code, func(t *testing.T) {
+			_, err := valueTypeForCIP(code)
+			if err == nil {
+				t.Fatalf("valueTypeForCIP(%q): expected error", code)
+			}
+			if errors.Kind(err) != errors.KindContractInvalid {
+				t.Errorf("kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+			}
+		})
+	}
+}
+
+// #6: the shared normalizer must fold the mixed casing seen in real profiles
+// (ethernetip-sim-profile.json has both "Uint8array" and "Uint8Array") to the
+// spelling the EdgeX validator accepts. We rely on common.NormalizeValueType
+// rather than a hand-rolled map; this test pins that reliance.
+func TestNormalizeValueTypeCasing(t *testing.T) {
+	for _, in := range []string{"Uint8array", "Uint8Array", "uint8array", "UINT8ARRAY"} {
+		got, err := common.NormalizeValueType(in)
+		if err != nil {
+			t.Fatalf("NormalizeValueType(%q): %v", in, err)
+		}
+		if got != common.ValueTypeUint8Array {
+			t.Errorf("NormalizeValueType(%q): got %q, want %q", in, got, common.ValueTypeUint8Array)
+		}
+	}
+}

--- a/pkg/profileconv/eds/convert.go
+++ b/pkg/profileconv/eds/convert.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 IOTech Ltd
+
+// Package eds converts an EtherNet/IP EDS (Electronic Data Sheet) into an EdgeX
+// DeviceProfile consumed by the XRT EtherNet/IP device service. Its Convert
+// function satisfies profileconv.ConvertFunc, so it slots in alongside other
+// source formats (xlsx, DBC…).
+//
+// The conversion is a three-stage pipeline, one file per stage, so each layer
+// owns a distinct concern and is tested in isolation:
+//
+//	parse    (parser.go)     EDS text  -> *eds: a generic, semantics-free tree
+//	                         of sections/entries/fields. Handles ONLY EDS grammar
+//	                         (";" termination, "," fields, "$" comments, quoting,
+//	                         multi-line statements) — no CIP meaning.
+//	extract  (extractor.go)  *eds -> *extracted: applies CIP meaning to the tree,
+//	                         pulling the positional fields the mapper needs into
+//	                         named structs (params, assemblies, connections, enum
+//	                         maps). Field-index knowledge lives here and nowhere
+//	                         else; the three mappers all read this one struct.
+//	map      (mapper*.go)    *extracted -> dtos.DeviceProfile: builds the device
+//	                         resources (implicit I/O, settings, explicit messaging)
+//	                         and enum DeviceCommands.
+//
+// Splitting extract from map keeps "which field index means what" in one place
+// and lets each mapper consume named fields instead of re-reading the raw tree.
+// This file (convert.go) is the entry point that orchestrates the three stages.
+package eds
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+
+	"github.com/IOTechSystems/go-mod-edge-connect-client/v4/pkg/profileconv"
+)
+
+// compile-time check that Convert satisfies the format-neutral contract.
+var _ profileconv.ConvertFunc = Convert
+
+// Convert turns one EtherNet/IP EDS file into an EdgeX DeviceProfile.
+//
+//	var convert profileconv.ConvertFunc = eds.Convert
+//	profile, err := convert(ctx, lc, data, nil)
+//
+// ctx and options are part of the ConvertFunc contract but currently unused:
+// parsing is a synchronous in-memory pass with no cancellation point, and
+// options is reserved for format-specific tuning.
+func Convert(ctx context.Context, lc logger.LoggingClient,
+	data []byte, options map[string]any) (dtos.DeviceProfile, errors.EdgeX) {
+	var profile dtos.DeviceProfile
+
+	// Stage 1 — parse: EDS text into a semantics-free section/entry/field tree.
+	edsTree, err := parse(bytes.NewReader(data))
+	if err != nil {
+		return profile, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	// Stage 2 — extract: apply CIP meaning, producing the structured middle layer.
+	extractedEds, err := extract(lc, edsTree)
+	if err != nil {
+		return profile, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	// Stage 3 — map: build the EdgeX device resources and commands.
+	profile, err = extractedEds.mapToProfile()
+	if err != nil {
+		return profile, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	// A named profile with no resources is not convertible content: a caller
+	// could not tell it apart from a successful conversion. Reject it explicitly
+	// (e.g. a modular device whose dynamic assemblies were all skipped).
+	if len(profile.DeviceResources) == 0 {
+		return profile, errors.NewCommonEdgeX(errors.KindContractInvalid, "EDS produced no device resources", nil)
+	}
+
+	// Validate the full struct (required fields, ValueType/ReadWrite enums) as
+	// well as the DTO-level duplicate-name/binary-write rules; ValidateDeviceProfileDTO
+	// alone would skip the struct-tag checks.
+	if verr := profile.Validate(); verr != nil {
+		return profile, errors.NewCommonEdgeXWrapper(verr)
+	}
+	return profile, nil
+}

--- a/pkg/profileconv/eds/convert_test.go
+++ b/pkg/profileconv/eds/convert_test.go
@@ -1,0 +1,264 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+// Convert must wrap a parse failure as an EdgeX error rather than panicking or
+// swallowing it.
+func TestConvertMalformedInputErrors(t *testing.T) {
+	lc := logger.NewMockClient()
+	// Unterminated statement (no ";") -> parse returns KindContractInvalid.
+	_, err := Convert(context.Background(), lc, []byte("[Device]\n    Name = \"x\"\n"), nil)
+	if err == nil {
+		t.Fatal("expected error for malformed EDS")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("error kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+	}
+}
+
+// convertSample converts the golden EDS and asserts it passes EdgeX validation,
+// returning the profile for the focused sub-tests below.
+func convertSample(t *testing.T) dtos.DeviceProfile {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "ethernetip-sample.eds"))
+	if err != nil {
+		t.Fatalf("read sample: %v", err)
+	}
+	profile, cerr := Convert(context.Background(), logger.NewMockClient(), data, nil)
+	if cerr != nil {
+		t.Fatalf("Convert on valid EDS: %v", cerr)
+	}
+	if verr := dtos.ValidateDeviceProfileDTO(profile); verr != nil {
+		t.Fatalf("validation: %v", verr)
+	}
+	return profile
+}
+
+// Convert on a well-formed EDS produces a validated profile carrying the device
+// identity and its I/O resources. Each aspect is a focused sub-test so a failure
+// pinpoints the broken part of the pipeline.
+func TestConvertValidInputSucceeds(t *testing.T) {
+	profile := convertSample(t)
+	rs := profile.DeviceResources
+
+	t.Run("identity", func(t *testing.T) {
+		if profile.Name != "ethernetip-sample" {
+			t.Errorf("profile Name: got %q, want ethernetip-sample", profile.Name)
+		}
+		if profile.Manufacturer != "Coverage Test Vendor" {
+			t.Errorf("profile Manufacturer: got %q", profile.Manufacturer)
+		}
+	})
+
+	t.Run("resource counts", func(t *testing.T) { assertResourceKinds(t, rs) })
+	t.Run("pads not leaked", func(t *testing.T) { assertPadsNotLeaked(t, rs) })
+	t.Run("io spot-check", func(t *testing.T) { assertIOResources(t, rs) })
+	t.Run("scaling", func(t *testing.T) { assertScaling(t, rs) })
+	t.Run("settings", func(t *testing.T) { assertSettings(t, rs) })
+	t.Run("explicit", func(t *testing.T) { assertExplicit(t, rs) })
+	t.Run("enum command", func(t *testing.T) { assertEnumCommand(t, profile) })
+}
+
+// Enum9 -> Output Mode becomes a DeviceCommand with resourceOperation.mappings.
+func assertEnumCommand(t *testing.T, profile dtos.DeviceProfile) {
+	t.Helper()
+	if len(profile.DeviceCommands) != 1 {
+		t.Fatalf("device commands: got %d, want 1 (Output Mode enum)", len(profile.DeviceCommands))
+	}
+	cmd := profile.DeviceCommands[0]
+	if cmd.Name != "Output Mode" || cmd.ReadWrite != common.ReadWrite_W {
+		t.Errorf("command: got name=%q rw=%q, want Output Mode/W", cmd.Name, cmd.ReadWrite)
+	}
+	if len(cmd.ResourceOperations) != 1 || cmd.ResourceOperations[0].DeviceResource != "Output Mode" {
+		t.Fatalf("resourceOperations: got %+v", cmd.ResourceOperations)
+	}
+	want := map[string]string{"0": "Idle", "1": "Run", "2": "Jog", "3": "Home"}
+	got := cmd.ResourceOperations[0].Mappings
+	if len(got) != len(want) {
+		t.Fatalf("mappings: got %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("mappings[%s]: got %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+// Total count and per-kind breakdown: 9 O2T I/O + 7 T2O I/O + 3 Settings +
+// 4 explicit = 23. Pads (2) and the config assembly's members produce none.
+// Locking the total catches a builder that drops or duplicates resources.
+func assertResourceKinds(t *testing.T, rs []dtos.DeviceResource) {
+	t.Helper()
+	if len(rs) != 23 {
+		t.Fatalf("total device resources: got %d, want 23", len(rs))
+	}
+	var io, settings, explicit int
+	for _, r := range rs {
+		typ, _ := r.Attributes[attrType].(string)
+		switch typ {
+		case typeO2T, typeT2O:
+			io++
+		case typeO2TSettings, typeT2OSettings, typeConfigSettings:
+			settings++
+		case "":
+			explicit++
+		}
+	}
+	if io != 16 || settings != 3 || explicit != 4 {
+		t.Errorf("resource kinds: io=%d settings=%d explicit=%d, want 16/3/4", io, settings, explicit)
+	}
+}
+
+// Pad members must not surface as resources.
+func assertPadsNotLeaked(t *testing.T, rs []dtos.DeviceResource) {
+	t.Helper()
+	for _, name := range []string{"RESERVED_pad5", "RESERVED_pad8"} {
+		for _, r := range rs {
+			if r.Name == name {
+				t.Errorf("pad member %q leaked into the profile", name)
+			}
+		}
+	}
+}
+
+// Spot-check representative resources across the pipeline, confirming each
+// builder's output reaches the final profile with the right values (per-value
+// golden assertions live in the mapper unit tests; this checks the wiring).
+func assertIOResources(t *testing.T, rs []dtos.DeviceResource) {
+	t.Helper()
+	type want struct {
+		typ                  string
+		offBytes             int
+		valueType, readWrite string
+	}
+	cases := map[string]want{
+		"DO Channel 0": {typeO2T, 0, common.ValueTypeBool, common.ReadWrite_W},    // BOOL bit-packed at byte0
+		"Output SINT":  {typeO2T, 1, common.ValueTypeInt8, common.ReadWrite_W},    // after 3 bits + 5-bit pad
+		"Output REAL":  {typeO2T, 8, common.ValueTypeFloat32, common.ReadWrite_W}, // 4-byte aligned
+		"Input LINT":   {typeT2O, 0, common.ValueTypeInt64, common.ReadWrite_R},   // T2O read side
+		"Input WORD":   {typeT2O, 26, common.ValueTypeUint16, common.ReadWrite_R}, // after an 8-bit pad
+		"Setpoint":     {typeO2T, 14, common.ValueTypeInt16, common.ReadWrite_W},  // O2T side of the shared point
+		"Setpoint_T2O": {typeT2O, 32, common.ValueTypeInt16, common.ReadWrite_R},  // T2O side, direction-suffixed
+	}
+	for name, w := range cases {
+		r := resourceByName(t, rs, name)
+		if r.Attributes[attrType] != w.typ || r.Attributes[attrOffsetBytes] != w.offBytes {
+			t.Errorf("%s: got type=%v byte=%v, want %s/%d", name, r.Attributes[attrType], r.Attributes[attrOffsetBytes], w.typ, w.offBytes)
+		}
+		if r.Properties.ValueType != w.valueType || r.Properties.ReadWrite != w.readWrite {
+			t.Errorf("%s: got %s/%s, want %s/%s", name, r.Properties.ValueType, r.Properties.ReadWrite, w.valueType, w.readWrite)
+		}
+	}
+}
+
+// Scaling reaches the profile: Output INT scaled has scale 0.1 and min -3200.
+func assertScaling(t *testing.T, rs []dtos.DeviceResource) {
+	t.Helper()
+	scaled := resourceByName(t, rs, "Output INT scaled")
+	if scaled.Properties.Scale == nil || *scaled.Properties.Scale != 0.1 {
+		t.Errorf("Output INT scaled scale: got %v, want 0.1", scaled.Properties.Scale)
+	}
+	if scaled.Properties.Minimum == nil || *scaled.Properties.Minimum != -3200 {
+		t.Errorf("Output INT scaled minimum: got %v, want -3200", scaled.Properties.Minimum)
+	}
+}
+
+// Settings: O2T (id 100, header true), T2O (id 101, header false), Config
+// (id 110, no header) — the includeHeader32bit rule per settings type.
+func assertSettings(t *testing.T, rs []dtos.DeviceResource) {
+	t.Helper()
+	o2tSet := resourceByName(t, rs, "Output Assembly O2TSettings")
+	if o2tSet.Attributes[attrAssemblyID] != 100 || o2tSet.Attributes[attrIncludeHeader32bit] != true {
+		t.Errorf("O2TSettings: got id=%v hdr=%v, want 100/true", o2tSet.Attributes[attrAssemblyID], o2tSet.Attributes[attrIncludeHeader32bit])
+	}
+	t2oSet := resourceByName(t, rs, "Input Assembly T2OSettings")
+	if t2oSet.Attributes[attrAssemblyID] != 101 || t2oSet.Attributes[attrIncludeHeader32bit] != false {
+		t.Errorf("T2OSettings: got id=%v hdr=%v, want 101/false", t2oSet.Attributes[attrAssemblyID], t2oSet.Attributes[attrIncludeHeader32bit])
+	}
+	cfgSet := resourceByName(t, rs, "Config Assembly ConfigSettings")
+	if cfgSet.Attributes[attrAssemblyID] != 110 {
+		t.Errorf("ConfigSettings assemblyID: got %v, want 110", cfgSet.Attributes[attrAssemblyID])
+	}
+	if _, ok := cfgSet.Attributes[attrIncludeHeader32bit]; ok {
+		t.Error("ConfigSettings must not carry includeHeader32bit")
+	}
+}
+
+// Explicit: SerialNumber (Identity/1/6, no type) and Short Label (vendor
+// object class 0x67=103) — Link Path EPATH decoded into objClass/instID/attrID.
+func assertExplicit(t *testing.T, rs []dtos.DeviceResource) {
+	t.Helper()
+	sn := resourceByName(t, rs, "SerialNumber (explicit)")
+	if _, hasType := sn.Attributes[attrType]; hasType {
+		t.Error("explicit resource must not have a type attribute")
+	}
+	if sn.Attributes[attrObjClass] != 1 || sn.Attributes[attrInstID] != 1 || sn.Attributes[attrAttrID] != 6 {
+		t.Errorf("SerialNumber: got %v, want objClass1/inst1/attr6", sn.Attributes)
+	}
+	if label := resourceByName(t, rs, "Short Label"); label.Attributes[attrObjClass] != 103 {
+		t.Errorf("Short Label objClass: got %v, want 103", label.Attributes[attrObjClass])
+	}
+}
+
+// A [Params] param with a Link Path becomes an explicit-messaging resource with
+// no dependence on a [Connection Manager]: an EDS with no connection at all still
+// converts, as long as it has such a param. (Implicit I/O and settings need a
+// connection; explicit messaging does not.)
+func TestConvertExplicitOnlyNoConnection(t *testing.T) {
+	eds := []byte("[Device]\n" +
+		"    ProdName = \"Explicit Only\";\n" +
+		"[Params]\n" +
+		"    Param1 = 0, 6, \"20 01 24 01 30 06\", 0x0000, 0xC8,4, \"SerialNumber\";\n")
+	profile, err := Convert(context.Background(), logger.NewMockClient(), eds, nil)
+	if err != nil {
+		t.Fatalf("Convert on explicit-only EDS: %v", err)
+	}
+	if verr := dtos.ValidateDeviceProfileDTO(profile); verr != nil {
+		t.Fatalf("validation: %v", verr)
+	}
+	if len(profile.DeviceResources) != 1 {
+		t.Fatalf("resources: got %d, want 1 (the explicit param)", len(profile.DeviceResources))
+	}
+	r := profile.DeviceResources[0]
+	if _, hasType := r.Attributes[attrType]; hasType {
+		t.Error("explicit resource must not have a type attribute")
+	}
+	if r.Attributes[attrObjClass] != 1 || r.Attributes[attrInstID] != 1 || r.Attributes[attrAttrID] != 6 {
+		t.Errorf("explicit attrs: got %v, want objClass1/inst1/attr6", r.Attributes)
+	}
+}
+
+// Input with no convertible content is a contract error, not a silent empty
+// profile. Three shapes must all be rejected: empty input, a [Params] section
+// with no [Device] name to derive from, and a named [Device] that yields no
+// resources at all (nothing for a caller to distinguish from a real result).
+func TestConvertNoConvertibleContentErrors(t *testing.T) {
+	cases := map[string][]byte{
+		"empty":           nil,
+		"no device":       []byte("[Params]\n    Param1 = 0,,,0x0000,0xC1,1,\"X\";\n"),
+		"named but empty": []byte("[Device]\n    VendCode = 1;\n    ProdName = \"WidgetX\";\n"),
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := Convert(context.Background(), logger.NewMockClient(), data, nil)
+			if err == nil {
+				t.Fatal("expected error for input with no convertible content")
+			}
+			if errors.Kind(err) != errors.KindContractInvalid {
+				t.Errorf("kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+			}
+		})
+	}
+}

--- a/pkg/profileconv/eds/epath.go
+++ b/pkg/profileconv/eds/epath.go
@@ -1,0 +1,116 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+// CIP logical segment types (the high bits of a segment byte). The low 2 bits
+// are the format: 0 = 8-bit value, 1 = 16-bit (little-endian), 2 = 32-bit.
+const (
+	segClass        = 0x20 // class id
+	segInstance     = 0x24 // instance id
+	segAttribute    = 0x30 // attribute id
+	segConnectionPt = 0x2C // connection point (an instance variant)
+	segFormatMask   = 0x03 // low 2 bits: value width (0=8-bit, 1=16-bit, 2=32-bit)
+)
+
+// epathSegment is one decoded CIP logical segment: its logical type (segClass /
+// segInstance / segAttribute / segConnectionPt, with the format bits cleared)
+// and its value.
+type epathSegment struct {
+	logicalType uint64
+	value       int
+}
+
+// parseEPATH decodes a CIP EPATH such as "20 04 24 64 30 03" into its logical
+// segments. It walks segment by segment — not token by token —
+// so a value byte that happens to equal a segment code is never mistaken for a
+// segment type. The format bits select the value width (8/16/32-bit,
+// little-endian). Returns an error on a malformed path (bad byte, truncated
+// value, or an unrecognised segment type).
+//
+// EDS paths use the CIP *padded* logical-segment encoding: a 16-bit or 32-bit
+// value is preceded by a single 0x00 pad byte (for 16-bit-word alignment), so
+// e.g. instance 256 is "25 00 00 01", not "25 00 01". An 8-bit value has no pad
+// (ODVA CIP Networks Library Vol.1, Appendix C).
+func parseEPATH(path string) ([]epathSegment, errors.EdgeX) {
+	toks := strings.Fields(strings.Trim(strings.TrimSpace(path), `"`))
+
+	var segs []epathSegment
+	for i := 0; i < len(toks); {
+		seg, consumed, err := decodeEPATHSegment(toks, i, path)
+		if err != nil {
+			return nil, err
+		}
+		segs = append(segs, seg)
+		i += consumed
+	}
+	return segs, nil
+}
+
+// decodeEPATHSegment decodes the logical segment starting at toks[i] and reports
+// how many tokens it consumed (type byte + optional pad + value bytes).
+func decodeEPATHSegment(toks []string, i int, path string) (epathSegment, int, errors.EdgeX) {
+	readByte := func(j int) (uint64, errors.EdgeX) {
+		v, err := strconv.ParseUint(toks[j], 16, 8)
+		if err != nil {
+			return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("invalid EPATH byte %q in path %q", toks[j], path), err)
+		}
+		return v, nil
+	}
+
+	seg, err := readByte(i)
+	if err != nil {
+		return epathSegment{}, 0, err
+	}
+	logicalType := seg &^ segFormatMask
+	format := seg & segFormatMask
+	if format == 3 { // 0/1/2 = 8/16/32-bit; 3 is reserved (invalid)
+		return epathSegment{}, 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("EPATH segment 0x%02X has a reserved size format in path %q", seg, path), nil)
+	}
+	switch logicalType {
+	case segClass, segInstance, segAttribute, segConnectionPt:
+	default:
+		return epathSegment{}, 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unexpected EPATH segment 0x%02X in path %q", seg, path), nil)
+	}
+
+	width := 1 << format // value byte count: 1/2/4
+	// Padded encoding: 16/32-bit values carry one 0x00 pad byte after the
+	// segment-type byte, so the value starts at i+1+pad.
+	pad := 0
+	if width > 1 {
+		pad = 1
+	}
+	// value bytes are toks[i+1+pad .. i+pad+width]; need that within bounds.
+	if i+pad+width >= len(toks) {
+		return epathSegment{}, 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("EPATH segment 0x%02X without its %d value byte(s): %q", seg, width, path), nil)
+	}
+
+	// The pad byte is defined as 0x00; a non-zero pad is a malformed path, not a
+	// value byte to fold in, so reject it rather than silently ignoring it.
+	if pad == 1 {
+		p, err := readByte(i + 1)
+		if err != nil {
+			return epathSegment{}, 0, err
+		}
+		if p != 0 {
+			return epathSegment{}, 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("EPATH segment 0x%02X has a non-zero pad byte 0x%02X in path %q", seg, p, path), nil)
+		}
+	}
+
+	var value uint64
+	for b := 0; b < width; b++ {
+		vb, err := readByte(i + 1 + pad + b)
+		if err != nil {
+			return epathSegment{}, 0, err
+		}
+		value |= vb << (8 * b) // little-endian
+	}
+	return epathSegment{logicalType: logicalType, value: int(value)}, 1 + pad + width, nil
+}

--- a/pkg/profileconv/eds/example_test.go
+++ b/pkg/profileconv/eds/example_test.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+
+	"github.com/IOTechSystems/go-mod-edge-connect-client/v4/pkg/profileconv"
+	"github.com/IOTechSystems/go-mod-edge-connect-client/v4/pkg/profileconv/eds"
+)
+
+// ExampleConvert shows converting one EtherNet/IP EDS into an EdgeX
+// DeviceProfile. eds.Convert satisfies profileconv.ConvertFunc, so it can be
+// used directly or through the format-neutral type.
+func ExampleConvert() {
+	edsData := []byte(`
+[Device]
+    VendName = "Demo Corp";
+    ProdName = "DEMO-DIO8";
+
+[Params]
+    Param1 = 0,,,0x0000,0xC1,1,"DO0";
+
+[Assembly]
+    Assem100 = "Outputs", "20 04 24 64 30 03", 1, 0x0000, , , 1, Param1;
+
+[Connection Manager]
+    Connection1 = 0x04020002, 0x44640405, , 1, Assem100, , , ;
+`)
+
+	var convert profileconv.ConvertFunc = eds.Convert
+	profile, err := convert(context.Background(), logger.NewMockClient(), edsData, nil)
+	if err != nil {
+		fmt.Println("convert failed:", err)
+		return
+	}
+	fmt.Println("name:", profile.Name)
+	fmt.Println("model:", profile.Model)
+
+	// Output:
+	// name: demo-dio8
+	// model: DEMO-DIO8
+}

--- a/pkg/profileconv/eds/explicit.go
+++ b/pkg/profileconv/eds/explicit.go
@@ -1,0 +1,79 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+// mapExplicit builds explicit-messaging resources from params that
+// carry a Link Path — a CIP object EPATH such as "20 01 24 01 30 06" giving
+// objClass/instID/attrID. An explicit resource has no type attribute.
+func (x *extracted) mapExplicit(names *nameSet) ([]dtos.DeviceResource, errors.EdgeX) {
+	var resources []dtos.DeviceResource
+	// Iterate params in key order so output is deterministic (map iteration is not).
+	paramKeys := make([]string, 0, len(x.params))
+	for k := range x.params {
+		paramKeys = append(paramKeys, k)
+	}
+	sort.Strings(paramKeys)
+
+	for _, k := range paramKeys {
+		p := x.params[k]
+		if strings.TrimSpace(p.linkPath) == "" {
+			continue
+		}
+		attrs, err := explicitAttrsFromLinkPath(p.linkPath)
+		if err != nil {
+			return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("explicit param %q", k), err)
+		}
+		valueType, verr := valueTypeForCIP(p.dataType)
+		if verr != nil {
+			return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("explicit param %q", k), verr)
+		}
+		resources = append(resources, dtos.DeviceResource{
+			Name:        names.unique(p.name, "explicit"),
+			Description: p.help,
+			Attributes:  attrs,
+			Properties:  paramProperties(p, valueType, common.ReadWrite_R),
+		})
+	}
+	return resources, nil
+}
+
+// explicitAttrsFromLinkPath parses a param Link Path EPATH into explicit-messaging
+// attributes. "20 01 24 01 30 06" -> objClass=1, instID=1, attrID=6. The class
+// and instance segments are required; the attribute segment is optional —
+// omitting it reads the whole instance (Get Attributes All). Uses the shared
+// parseEPATH walker; a duplicate class/instance/attribute segment is rejected here.
+func explicitAttrsFromLinkPath(path string) (map[string]any, errors.EdgeX) {
+	segs, err := parseEPATH(path)
+	if err != nil {
+		return nil, err
+	}
+	attrs := map[string]any{}
+	key := map[uint64]string{segClass: attrObjClass, segInstance: attrInstID, segAttribute: attrAttrID}
+	for _, s := range segs {
+		k, ok := key[s.logicalType]
+		if !ok {
+			return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unexpected Link Path segment 0x%02X in %q", s.logicalType, path), nil)
+		}
+		if _, dup := attrs[k]; dup {
+			return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("duplicate %s segment in Link Path %q", k, path), nil)
+		}
+		attrs[k] = s.value
+	}
+	if _, ok := attrs[attrObjClass]; !ok {
+		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("Link Path %q missing class segment", path), nil)
+	}
+	if _, ok := attrs[attrInstID]; !ok {
+		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("Link Path %q missing instance segment", path), nil)
+	}
+	return attrs, nil
+}

--- a/pkg/profileconv/eds/extractor.go
+++ b/pkg/profileconv/eds/extractor.go
@@ -1,0 +1,337 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+// extracted is the structured, still-CIP-agnostic middle layer between the raw
+// AST and the mapper. It pulls the fields the mapper needs out of positional
+// entries so later stages read named fields, not slice indices. Field positions
+// follow the ODVA EDS spec.
+type extracted struct {
+	device      deviceInfo
+	params      map[string]param // keyed by ParamN name, e.g. "Param1"
+	assemblies  map[string]assembly
+	connections []connection
+	// isModular is set when a modular-device marker is seen while walking the
+	// EDS: a [Modular] section or a ProxyConnectN entry. Such a device's dynamic
+	// I/O cannot be derived from a single EDS; how to surface that is not
+	// decided yet, so this flag is detected but not yet acted on.
+	isModular bool
+	// enumOps accumulates the (resource, readWrite, mappings) triples for I/O
+	// resources whose param carries an EnumN, collected while building resources
+	// (so names match the emitted resource) and turned into DeviceCommands.
+	enumOps []enumOp
+}
+
+// enumOp records an emitted I/O resource that has an enum value->label map, used
+// to build a DeviceCommand carrying resourceOperation.mappings.
+type enumOp struct {
+	resource  string
+	readWrite string
+	mappings  map[string]string
+}
+
+// deviceInfo holds the [Device] identity fields used to build the profile shell.
+type deviceInfo struct {
+	vendorName  string
+	productName string
+	catalog     string
+}
+
+// param is one [Params] ParamN entry, fields kept verbatim; the mapper casts
+// them per the data type. linkPath non-empty marks an explicit-messaging param.
+type param struct {
+	name       string
+	dataType   string // CIP type code as written (e.g. "0xC3")
+	dataSize   string
+	units      string
+	help       string
+	minimum    string
+	maximum    string
+	defaultVal string
+	scaleMult  string
+	scaleDiv   string
+	scaleBase  string
+	scaleOff   string
+	linkPath   string
+	enum       map[string]string // enum value -> label, from the matching EnumN entry
+}
+
+// assembly is one [Assembly] AssemN: its parsed instance id, declared size, and
+// ordered members. Each member is a (bit length, ParamN reference) pair; the
+// order determines each point's offset (computed later, in the mapper).
+type assembly struct {
+	name       string
+	assemblyID int
+	size       string
+	members    []assemblyMember
+}
+
+type assemblyMember struct {
+	bitLength string
+	paramRef  string // ParamN name, or "" for an unreferenced/pad slot
+}
+
+// connection is one [Connection Manager] ConnectionN, reduced to the references
+// that decide direction and the header flag. o2tFormat/t2oFormat/configFormat
+// name the assemblies this connection uses ("" if absent).
+type connection struct {
+	connectionParams string // field 1: real-time format bit -> includeHeader32bit
+	o2tFormat        string // field 4: output assembly (writable)
+	t2oFormat        string // field 7: input assembly (read-only)
+	configFormat     string // field 11: config assembly
+}
+
+// Entry keyword prefixes that mark the numbered entries in each section
+// (ParamN, EnumN, AssemN, ConnectionN, ProxyConnectN). Other keywords (object
+// metadata) are skipped.
+const (
+	keywordParam        = "Param"
+	keywordEnum         = "Enum"
+	keywordAssembly     = "Assem"
+	keywordConnection   = "Connection"
+	keywordProxyConnect = "ProxyConnect"
+)
+
+// [Device] identity keywords used to build the profile shell.
+const (
+	deviceVendName = "VendName"
+	deviceProdName = "ProdName"
+	deviceCatalog  = "Catalog"
+)
+
+// Field indices into each positional entry (0-indexed on the fields after "=").
+// Positions follow the ODVA EDS spec for [Params], [Assembly], and [Connection].
+
+// [Params] ParamN fields.
+const (
+	paramLinkPath  = 2
+	paramDataType  = 4
+	paramDataSize  = 5
+	paramName      = 6
+	paramUnits     = 7
+	paramHelp      = 8
+	paramMinimum   = 9
+	paramMaximum   = 10
+	paramDefault   = 11
+	paramScaleMult = 12
+	paramScaleDiv  = 13
+	paramScaleBase = 14
+	paramScaleOff  = 15
+)
+
+// [Assembly] AssemN fields; members are (size, ref) pairs from assemblyFirstMember.
+const (
+	assemblyPath        = 1
+	assemblySize        = 2
+	assemblyFirstMember = 6
+)
+
+// [Connection Manager] ConnectionN fields.
+const (
+	connectionParams = 1
+	connectionO2T    = 4
+	connectionT2O    = 7
+	connectionConfig = 11
+)
+
+// extract reduces the parsed AST to the structured middle layer. Missing
+// sections yield empty maps rather than errors — the mapper decides what is
+// required — but a malformed assembly Path (unparseable instance id) is an error.
+func extract(lc logger.LoggingClient, e *eds) (*extracted, errors.EdgeX) {
+	out := &extracted{
+		params:     map[string]param{},
+		assemblies: map[string]assembly{},
+	}
+
+	if dev := e.section(sectionDevice); dev != nil {
+		out.device = deviceInfo{
+			vendorName:  entryField(dev, deviceVendName),
+			productName: entryField(dev, deviceProdName),
+			catalog:     entryField(dev, deviceCatalog),
+		}
+	}
+
+	extractParams(out, e)
+	if err := extractAssemblies(lc, out, e); err != nil {
+		return nil, err
+	}
+	// A [Modular] section marks a modular device.
+	if e.section(sectionModular) != nil {
+		out.isModular = true
+	}
+	extractConnections(out, e)
+
+	return out, nil
+}
+
+// extractParams fills out.params from the [Params] section. A ParamN's matching
+// EnumN sub-entry (paired by N) is attached as its value->label map.
+func extractParams(out *extracted, e *eds) {
+	for _, en := range e.sectionEntries(sectionParams) {
+		// EnumN must be checked first: it is not a Param prefix, but keep the
+		// dispatch explicit so a future keyword is not silently misrouted.
+		if strings.HasPrefix(en.keyword, keywordEnum) {
+			continue // handled in the merge pass below
+		}
+		if !strings.HasPrefix(en.keyword, keywordParam) {
+			continue // object metadata (Object_Name, Revision…)
+		}
+		out.params[en.keyword] = param{
+			name:       en.field(paramName),
+			dataType:   en.field(paramDataType),
+			dataSize:   en.field(paramDataSize),
+			units:      en.field(paramUnits),
+			help:       en.field(paramHelp),
+			minimum:    en.field(paramMinimum),
+			maximum:    en.field(paramMaximum),
+			defaultVal: en.field(paramDefault),
+			scaleMult:  en.field(paramScaleMult),
+			scaleDiv:   en.field(paramScaleDiv),
+			scaleBase:  en.field(paramScaleBase),
+			scaleOff:   en.field(paramScaleOff),
+			linkPath:   en.field(paramLinkPath),
+		}
+	}
+	attachEnums(out, e)
+}
+
+// attachEnums walks the [Params] section for EnumN entries and attaches each to
+// its ParamN (paired by the number N). An EnumN whose ParamN is absent is
+// ignored. EnumN fields are (value, label) pairs from index 0.
+func attachEnums(out *extracted, e *eds) {
+	for _, en := range e.sectionEntries(sectionParams) {
+		if !strings.HasPrefix(en.keyword, keywordEnum) {
+			continue
+		}
+		n := strings.TrimPrefix(en.keyword, keywordEnum)
+		p, ok := out.params[keywordParam+n]
+		if !ok {
+			continue // Enum without a matching Param — nothing to attach to
+		}
+		mappings := map[string]string{}
+		for i := 0; i+1 < len(en.fields); i += 2 {
+			value := strings.TrimSpace(en.field(i))
+			label := strings.TrimSpace(en.field(i + 1))
+			if value != "" {
+				mappings[value] = label
+			}
+		}
+		if len(mappings) > 0 {
+			p.enum = mappings
+			out.params[keywordParam+n] = p
+		}
+	}
+}
+
+// extractAssemblies fills out.assemblies from the [Assembly] section. A blank
+// Path (dynamic/placeholder assembly) is skipped; a malformed non-blank Path is
+// an error.
+func extractAssemblies(lc logger.LoggingClient, out *extracted, e *eds) errors.EdgeX {
+	for _, en := range e.sectionEntries(sectionAssembly) {
+		if !strings.HasPrefix(en.keyword, keywordAssembly) {
+			continue // object metadata entries (Object_Name, Revision…)
+		}
+		// A blank Path is a dynamic/placeholder assembly (common in modular
+		// devices, where the layout is not in the EDS). Skip it rather than
+		// error; if a real connection references it, that surfaces later as an
+		// unknown-assembly error.
+		if strings.TrimSpace(strings.Trim(en.field(assemblyPath), `"`)) == "" {
+			lc.Debugf("eds: skipping assembly %q with no Path (dynamic/placeholder assembly)", en.keyword)
+			continue
+		}
+		id, err := assemblyIDFromPath(en.field(assemblyPath))
+		if err != nil {
+			return errors.NewCommonEdgeXWrapper(err)
+		}
+		out.assemblies[en.keyword] = assembly{
+			name:       en.field(0),
+			assemblyID: id,
+			size:       en.field(assemblySize),
+			members:    extractMembers(en),
+		}
+	}
+	return nil
+}
+
+// extractConnections fills out.connections from the [Connection Manager] section
+// and flags modular devices via ProxyConnectN entries.
+func extractConnections(out *extracted, e *eds) {
+	for _, en := range e.sectionEntries(sectionConnectionManager) {
+		// ProxyConnectN entries are modular markers: connections proxied on
+		// behalf of plug-in modules, whose dynamic I/O we cannot lay out.
+		if strings.HasPrefix(en.keyword, keywordProxyConnect) {
+			out.isModular = true
+			continue
+		}
+		if !strings.HasPrefix(en.keyword, keywordConnection) {
+			continue
+		}
+		out.connections = append(out.connections, connection{
+			connectionParams: en.field(connectionParams),
+			o2tFormat:        en.field(connectionO2T),
+			t2oFormat:        en.field(connectionT2O),
+			configFormat:     en.field(connectionConfig),
+		})
+	}
+}
+
+// assemblyByName returns the extracted assembly a connection references, or a
+// KindContractInvalid error naming the missing assembly. Shared by the I/O and
+// settings mappers so the "unknown assembly" error is worded in one place.
+func (x *extracted) assemblyByName(name string) (assembly, errors.EdgeX) {
+	asm, ok := x.assemblies[name]
+	if !ok {
+		return assembly{}, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("connection references unknown assembly %q", name), nil)
+	}
+	return asm, nil
+}
+
+// entryField returns field 0 of the named keyword entry in a section, or "".
+// Used for the keyword=value entries of [Device].
+func entryField(s *section, keyword string) string {
+	if en := s.entry(keyword); en != nil {
+		return en.field(0)
+	}
+	return ""
+}
+
+// extractMembers reads the (bit length, ParamN) member pairs that start at
+// assemblyFirstMember. field(i+1) is "" when the ref column is the last field
+// (an empty-size member ending the entry), so the pair is still captured rather
+// than dropped.
+func extractMembers(en *entry) []assemblyMember {
+	var members []assemblyMember
+	for i := assemblyFirstMember; i < len(en.fields); i += 2 {
+		bits, ref := en.field(i), en.field(i+1)
+		if bits == "" && ref == "" {
+			continue // empty reserved slot between fields, not a member
+		}
+		members = append(members, assemblyMember{bitLength: bits, paramRef: ref})
+	}
+	return members
+}
+
+// assemblyIDFromPath parses the assembly instance id from an EDS Path EPATH via
+// parseEPATH: the value of the first instance or connection-point segment.
+// (Config paths legitimately carry several connection-point segments, e.g.
+// "20 04 24 80 2C 70 2C 64"; the first is the assembly instance.)
+func assemblyIDFromPath(path string) (int, errors.EdgeX) {
+	segs, err := parseEPATH(path)
+	if err != nil {
+		return 0, err
+	}
+	for _, s := range segs {
+		if s.logicalType == segInstance || s.logicalType == segConnectionPt {
+			return s.value, nil
+		}
+	}
+	return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("no assembly instance segment in path %q", path), nil)
+}

--- a/pkg/profileconv/eds/extractor_test.go
+++ b/pkg/profileconv/eds/extractor_test.go
@@ -1,0 +1,285 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+func extractSample(t *testing.T) *extracted {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "ethernetip-sample.eds"))
+	if err != nil {
+		t.Fatalf("read sample: %v", err)
+	}
+	e, perr := parse(bytes.NewReader(data))
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	x, xerr := extract(logger.NewMockClient(), e)
+	if xerr != nil {
+		t.Fatalf("extract: %v", xerr)
+	}
+	return x
+}
+
+func TestExtractDevice(t *testing.T) {
+	x := extractSample(t)
+	if x.device.vendorName != "Coverage Test Vendor" {
+		t.Errorf("vendorName: got %q", x.device.vendorName)
+	}
+	if x.device.productName != "EtherNetIP Sample" {
+		t.Errorf("productName: got %q", x.device.productName)
+	}
+}
+
+func TestExtractParams(t *testing.T) {
+	x := extractSample(t)
+	// Param6 is the INT with scaling: name, type, units, scale mult/div.
+	p, ok := x.params["Param6"]
+	if !ok {
+		t.Fatal("Param6 missing from lookup")
+	}
+	if p.name != "Output INT scaled" {
+		t.Errorf("Param6 name: got %q", p.name)
+	}
+	if p.dataType != "0xC3" {
+		t.Errorf("Param6 dataType: got %q, want 0xC3", p.dataType)
+	}
+	if p.units != "deg" {
+		t.Errorf("Param6 units: got %q, want deg", p.units)
+	}
+	if p.scaleMult != "1" || p.scaleDiv != "10" {
+		t.Errorf("Param6 scale: got mult=%q div=%q, want 1/10", p.scaleMult, p.scaleDiv)
+	}
+	// Param22 is explicit (has a Link Path).
+	if x.params["Param22"].linkPath == "" {
+		t.Error("Param22 should have a Link Path (explicit param)")
+	}
+	// Param1 is implicit (no Link Path).
+	if x.params["Param1"].linkPath != "" {
+		t.Errorf("Param1 should have no Link Path, got %q", x.params["Param1"].linkPath)
+	}
+}
+
+// Enum9 (value->label) must attach to Param9 by matching N; a param without an
+// EnumN carries no enum.
+func TestExtractParamEnum(t *testing.T) {
+	x := extractSample(t)
+	got := x.params["Param9"].enum
+	want := map[string]string{"0": "Idle", "1": "Run", "2": "Jog", "3": "Home"}
+	if len(got) != len(want) {
+		t.Fatalf("Param9 enum: got %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("Param9 enum[%s]: got %q, want %q", k, got[k], v)
+		}
+	}
+	if x.params["Param1"].enum != nil {
+		t.Errorf("Param1 should have no enum, got %v", x.params["Param1"].enum)
+	}
+}
+
+// attachEnums robustness: an EnumN with no matching ParamN is dropped (no panic),
+// an odd field count drops the trailing unpaired value, and an empty value is
+// skipped — the remaining clean pairs still attach.
+func TestExtractParamEnumEdgeCases(t *testing.T) {
+	src := "[Params]\n" +
+		"    Param1 = 0,,,0x0000,0xC7,2,\"Mode\",\"\",\"help\";\n" +
+		"    Enum1 = 0,\"Idle\", 1,\"Run\", 2;\n" + // odd: trailing "2" has no label
+		"    Enum7 = 0,\"Orphan\";\n" // no Param7 -> dropped
+	e, perr := parse(bytes.NewReader([]byte(src)))
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	x, err := extract(logger.NewMockClient(), e)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	// Param1 keeps only the two complete pairs; the trailing "2" is dropped.
+	got := x.params["Param1"].enum
+	want := map[string]string{"0": "Idle", "1": "Run"}
+	if len(got) != len(want) {
+		t.Fatalf("Param1 enum: got %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("Param1 enum[%s]: got %q, want %q", k, got[k], v)
+		}
+	}
+	// Enum7 had no Param7 -> nothing created, no panic.
+	if _, ok := x.params["Param7"]; ok {
+		t.Error("orphan Enum7 should not create a Param7")
+	}
+}
+
+func TestExtractAssembly(t *testing.T) {
+	x := extractSample(t)
+	a, ok := x.assemblies["Assem100"]
+	if !ok {
+		t.Fatal("Assem100 missing")
+	}
+	if a.assemblyID != 100 { // 0x64
+		t.Errorf("Assem100 id: got %d, want 100", a.assemblyID)
+	}
+	if a.size != "16" {
+		t.Errorf("Assem100 size: got %q, want 16", a.size)
+	}
+	// Assem100 has 10 members: DO0/DO1/DO2 (1 bit), a 5-bit pad, then SINT/INT/
+	// DINT/REAL/UINT/Setpoint. Lock the exact count so a misalignment that
+	// adds or drops a member is caught.
+	wantRefs := []string{"Param1", "Param2", "Param3", "Param4", "Param5", "Param6", "Param7", "Param8", "Param9", "Param24"}
+	if len(a.members) != len(wantRefs) {
+		t.Fatalf("Assem100 members: got %d %+v, want %d", len(a.members), a.members, len(wantRefs))
+	}
+	for i, want := range wantRefs {
+		if a.members[i].paramRef != want {
+			t.Errorf("member %d ref: got %q, want %q", i, a.members[i].paramRef, want)
+		}
+	}
+	// member[3] is the pad: 5 bits, referencing the RESERVED param (kept, not
+	// dropped — the mapper decides pads produce no resource).
+	if a.members[0].bitLength != "1" || a.members[3].bitLength != "5" {
+		t.Errorf("member bit lengths: got [0]=%q [3]=%q, want 1 and 5", a.members[0].bitLength, a.members[3].bitLength)
+	}
+	if a.members[3].paramRef != "Param4" {
+		t.Errorf("pad member[3] ref: got %q, want Param4", a.members[3].paramRef)
+	}
+}
+
+// Assem101 uses the empty-size member style (", Param10" — bit length omitted,
+// taken from the param's Data Size later). Members must still be captured with
+// an empty bitLength, not dropped.
+func TestExtractAssemblyEmptySizeMembers(t *testing.T) {
+	a := extractSample(t).assemblies["Assem101"]
+	if a.assemblyID != 101 { // 0x65
+		t.Fatalf("Assem101 id: got %d, want 101", a.assemblyID)
+	}
+	if len(a.members) == 0 {
+		t.Fatal("Assem101 members dropped (empty-size style not handled)")
+	}
+	m0 := a.members[0]
+	if m0.paramRef != "Param10" || m0.bitLength != "" {
+		t.Errorf("Assem101 member[0]: got bits=%q ref=%q, want bits=\"\" ref=Param10", m0.bitLength, m0.paramRef)
+	}
+}
+
+func TestExtractConnection(t *testing.T) {
+	x := extractSample(t)
+	if len(x.connections) != 1 {
+		t.Fatalf("connections: got %d, want 1", len(x.connections))
+	}
+	c := x.connections[0]
+	if c.o2tFormat != "Assem100" {
+		t.Errorf("o2tFormat: got %q, want Assem100", c.o2tFormat)
+	}
+	if c.t2oFormat != "Assem101" {
+		t.Errorf("t2oFormat: got %q, want Assem101", c.t2oFormat)
+	}
+	if c.configFormat != "Assem110" {
+		t.Errorf("configFormat: got %q, want Assem110", c.configFormat)
+	}
+	// field 1 drives includeHeader32bit later; it is the most off-by-one-prone
+	// field, so pin its value.
+	if c.connectionParams != "0x44640405" {
+		t.Errorf("connectionParams: got %q, want 0x44640405", c.connectionParams)
+	}
+}
+
+func TestAssemblyIDFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want int
+	}{
+		{"20 04 24 64 30 03", 100},       // 0x64 8-bit instance
+		{"20 04 24 65 30 03", 101},       // 0x65
+		{"20 04 24 6E 30 03", 110},       // 0x6E
+		{`"20 04 24 64 30 03"`, 100},     // quoted as it appears in EDS
+		{"20 04 2C 64", 100},             // 8-bit connection point
+		{"20 04 2D 00 00 01", 256},       // 16-bit connection point: pad 00, then 00 01 LE
+		{"20 04 25 00 00 01 30 03", 256}, // 16-bit instance (id >= 256): pad 00, then 00 01 LE
+		// class value 0x24 must NOT be read as an instance segment; the
+		// pairwise walk skips the (0x20, 0x24) class pair and reads (0x24, 0x64).
+		{"20 24 24 64 30 03", 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got, err := assemblyIDFromPath(tt.path)
+			if err != nil {
+				t.Fatalf("assemblyIDFromPath(%q): %v", tt.path, err)
+			}
+			if got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAssemblyIDFromPathErrors(t *testing.T) {
+	// "20 04 27 ..." : 0x27 = instance segment with reserved size format (bits=3).
+	// "20 04 25 FF 00 01" : 16-bit instance whose pad byte is non-zero (must be 0x00).
+	for _, path := range []string{"", "20 04 30 03", "nothex", "20 04 27 01 02", "20 04 25 FF 00 01"} {
+		t.Run(path, func(t *testing.T) {
+			_, err := assemblyIDFromPath(path)
+			if err == nil {
+				t.Fatalf("expected error for %q", path)
+			}
+			if errors.Kind(err) != errors.KindContractInvalid {
+				t.Errorf("kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+			}
+		})
+	}
+}
+
+// A blank assembly Path (a dynamic/placeholder assembly, common in modular
+// devices) is skipped rather than causing extract to fail. A malformed non-blank
+// Path is still an error.
+func TestExtractSkipsBlankPathAssembly(t *testing.T) {
+	src := "[Assembly]\n" +
+		"    Assem1 = \"Fixed\", \"20 04 24 64 30 03\", 2, 0x0, , , 8, Param1;\n" +
+		"    Assem2 = \"Dynamic\", , 0, 0x0, , ;\n" // blank Path
+	e, perr := parse(bytes.NewReader([]byte(src)))
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	x, err := extract(logger.NewMockClient(), e)
+	if err != nil {
+		t.Fatalf("extract should skip blank-path assembly, not error: %v", err)
+	}
+	if _, ok := x.assemblies["Assem1"]; !ok {
+		t.Error("fixed assembly with a valid path should be kept")
+	}
+	if _, ok := x.assemblies["Assem2"]; ok {
+		t.Error("blank-path assembly should be skipped")
+	}
+}
+
+// A repeated section (e.g. two [Params] blocks) must have all its entries read,
+// not just the first block's — otherwise later params silently vanish.
+func TestExtractMergesRepeatedSection(t *testing.T) {
+	src := "[Params]\n" +
+		"    Param1 = 0,,,0x0000,0xC1,1,\"A\";\n" +
+		"[Params]\n" +
+		"    Param2 = 0,,,0x0000,0xC1,1,\"B\";\n"
+	e, perr := parse(bytes.NewReader([]byte(src)))
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	x, err := extract(logger.NewMockClient(), e)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if _, ok := x.params["Param1"]; !ok {
+		t.Error("Param1 (first [Params] block) missing")
+	}
+	if _, ok := x.params["Param2"]; !ok {
+		t.Error("Param2 (second [Params] block) dropped — repeated section not merged")
+	}
+}

--- a/pkg/profileconv/eds/mapper.go
+++ b/pkg/profileconv/eds/mapper.go
@@ -1,0 +1,408 @@
+// Copyright (C) 2026 IOTech Ltd
+
+// This file is the EDS mapping layer: it turns the extracted middle layer into
+// an EdgeX DeviceProfile, applying the CIP-to-profile rules.
+
+package eds
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+// XRT EtherNet/IP resource attribute keys and type values.
+const (
+	maxOffsetBytes = 2000 // XRT implicit I/O offsetBytes upper bound
+
+	// A param name with this prefix marks a pad/reserved member (EDS convention,
+	// e.g. "RESERVED_pad5"); see isPadMember.
+	reservedPrefix = "RESERVED"
+)
+
+// resourceBuilder builds one kind of device resource, appending unique names to
+// seen. Implicit I/O, settings and explicit messaging each provide one (as a
+// method on *extracted).
+type resourceBuilder func(names *nameSet) ([]dtos.DeviceResource, errors.EdgeX)
+
+// mapToProfile builds the EdgeX DeviceProfile from the extracted middle layer:
+// the identity shell plus device resources (implicit I/O, settings, explicit
+// messaging).
+func (x *extracted) mapToProfile() (dtos.DeviceProfile, errors.EdgeX) {
+	var profile dtos.DeviceProfile
+
+	x.enumOps = nil // per-pass scratch; clear so remapping stays idempotent
+
+	// name (a sanitized identifier) and model (the human-readable original) both
+	// come from ProdName, falling back to Catalog. Fall back on the sanitized
+	// result being empty, not the raw string, so a ProdName of only whitespace
+	// (which sanitizes to "") still yields to a usable Catalog.
+	model := x.device.productName
+	name := sanitizeName(model)
+	if name == "" {
+		model = x.device.catalog
+		name = sanitizeName(model)
+	}
+	if name == "" {
+		return profile, errors.NewCommonEdgeX(errors.KindContractInvalid, "cannot derive profile name: EDS [Device] has no usable ProdName or Catalog", nil)
+	}
+
+	profile.Name = name
+	profile.Manufacturer = x.device.vendorName
+	profile.Model = model
+
+	// A single name set shared across all resource kinds keeps every name unique
+	// for ValidateDeviceProfileDTO.
+	names := newNameSet()
+	var resources []dtos.DeviceResource
+	for _, build := range []resourceBuilder{x.mapImplicitIO, x.mapSettings, x.mapExplicit} {
+		built, err := build(names)
+		if err != nil {
+			return profile, err
+		}
+		resources = append(resources, built...)
+	}
+	profile.DeviceResources = resources
+	profile.DeviceCommands = x.enumCommands()
+	return profile, nil
+}
+
+// enumCommands turns the enum resources collected during I/O mapping into
+// DeviceCommands, each with a single resourceOperation carrying the value->label
+// mappings. Returns nil when there are none, so the profile omits deviceCommands.
+func (x *extracted) enumCommands() []dtos.DeviceCommand {
+	if len(x.enumOps) == 0 {
+		return nil
+	}
+	commands := make([]dtos.DeviceCommand, 0, len(x.enumOps))
+	for _, op := range x.enumOps {
+		commands = append(commands, dtos.DeviceCommand{
+			Name:      op.resource,
+			ReadWrite: op.readWrite,
+			ResourceOperations: []dtos.ResourceOperation{
+				{DeviceResource: op.resource, Mappings: op.mappings},
+			},
+		})
+	}
+	return commands
+}
+
+// mapImplicitIO builds the implicit I/O resources from the assemblies a
+// connection uses. Direction comes from the connection: an assembly referenced
+// as O2T format is output (W), as T2O format is input (R).
+//
+// Per the XRT model a bidirectional point is two distinct resources — one O2T
+// and one T2O, each with its own offset — not one RW resource, so a param used
+// in both an output and an input assembly produces two resources. Resource names
+// must be unique for ValidateDeviceProfileDTO, so a colliding name is suffixed
+// (see nameSet).
+//
+// Each assembly's members are walked in order, accumulating a bit offset; a pad
+// member advances the offset but yields no resource. Alignment padding is
+// expected to be expressed explicitly by the EDS (a pad member filling the gap),
+// so offsets are a plain running sum of member bit lengths, starting at bit 0.
+func (x *extracted) mapImplicitIO(names *nameSet) ([]dtos.DeviceResource, errors.EdgeX) {
+	var resources []dtos.DeviceResource
+	expanded := map[string]bool{} // (assembly, direction) pairs already built
+
+	for _, c := range x.connections {
+		for _, ref := range []struct {
+			asmName string
+			typ     string
+		}{
+			{c.o2tFormat, typeO2T},
+			{c.t2oFormat, typeT2O},
+		} {
+			if ref.asmName == "" {
+				continue
+			}
+			// Multiple connections often share one assembly (e.g. exclusive-owner
+			// plus listen-only); build each (assembly, direction) only once.
+			key := ref.asmName + "/" + ref.typ
+			if expanded[key] {
+				continue
+			}
+			expanded[key] = true
+
+			built, err := x.buildAssemblyResources(ref.asmName, ref.typ, names)
+			if err != nil {
+				return nil, err
+			}
+			resources = append(resources, built...)
+		}
+	}
+	return resources, nil
+}
+
+// buildAssemblyResources walks one assembly's members in order, accumulating a
+// bit offset, and returns one I/O resource per non-pad member. typ is the XRT
+// direction type (O2T = write, T2O = read). seen carries the resource names
+// already emitted so uniqueName can keep every name distinct.
+func (x *extracted) buildAssemblyResources(asmName, typ string, names *nameSet) ([]dtos.DeviceResource, errors.EdgeX) {
+	asm, err := x.assemblyByName(asmName)
+	if err != nil {
+		return nil, err
+	}
+
+	readWrite := common.ReadWrite_W
+	if typ == typeT2O {
+		readWrite = common.ReadWrite_R
+	}
+
+	var resources []dtos.DeviceResource
+	offsetBits := 0
+	for _, m := range asm.members {
+		r, bits, produced, err := x.buildMemberResource(asmName, typ, readWrite, m, offsetBits, names)
+		if err != nil {
+			return nil, err
+		}
+		if produced {
+			resources = append(resources, r)
+		}
+		offsetBits += bits
+	}
+
+	if err := checkAssemblySize(asmName, asm.size, offsetBits); err != nil {
+		return nil, err
+	}
+	return resources, nil
+}
+
+// buildMemberResource maps one assembly member at the running offsetBits. A pad
+// member advances the offset but yields no resource (produced=false); a real
+// member returns its resource. bits is always the member's bit length so the
+// caller can advance the offset regardless.
+func (x *extracted) buildMemberResource(asmName, typ, readWrite string, m assemblyMember, offsetBits int, names *nameSet) (r dtos.DeviceResource, bits int, produced bool, err errors.EdgeX) {
+	p, hasParam := x.params[m.paramRef]
+
+	bits, err = memberBitLength(m, p, hasParam)
+	if err != nil {
+		return r, 0, false, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("assembly %q member %q", asmName, m.paramRef), err)
+	}
+	if isPadMember(m, p) {
+		return r, bits, false, nil
+	}
+	if !hasParam {
+		return r, 0, false, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("assembly %q member references unknown param %q", asmName, m.paramRef), nil)
+	}
+
+	valueType, verr := valueTypeForCIP(p.dataType)
+	if verr != nil {
+		return r, 0, false, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("assembly %q member %q", asmName, m.paramRef), verr)
+	}
+	offsetBytes := offsetBits / 8
+	if offsetBytes > maxOffsetBytes {
+		return r, 0, false, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("assembly %q member %q offsetBytes %d exceeds max %d", asmName, m.paramRef, offsetBytes, maxOffsetBytes), nil)
+	}
+	attrs := map[string]any{
+		attrType:        typ,
+		attrOffsetBytes: offsetBytes,
+		attrOffsetBits:  offsetBits % 8,
+	}
+	// bitLength is optional for Bool (a single bit); omit it to match XRT
+	// profiles, which leave it off Bool resources.
+	if valueType != common.ValueTypeBool {
+		attrs[attrBitLength] = bits
+	}
+	resName := names.unique(p.name, typ)
+	// An enumerated param becomes a DeviceCommand with resourceOperation.mappings;
+	// record it here so the command targets the emitted (possibly suffixed) name.
+	if len(p.enum) > 0 {
+		x.enumOps = append(x.enumOps, enumOp{resource: resName, readWrite: readWrite, mappings: p.enum})
+	}
+	return dtos.DeviceResource{
+		Name:        resName,
+		Description: p.help,
+		Attributes:  attrs,
+		Properties:  paramProperties(p, valueType, readWrite),
+	}, bits, true, nil
+}
+
+// checkAssemblySize cross-checks members against the assembly's declared Size:
+// the members must not overrun the declared byte length. Catches an EDS whose
+// Size and member layout disagree, which would otherwise produce an inconsistent
+// profile. A blank or unparseable Size is not enforced.
+func checkAssemblySize(asmName, size string, offsetBits int) errors.EdgeX {
+	sz := strings.TrimSpace(size)
+	if sz == "" {
+		return nil
+	}
+	declared, err := strconv.Atoi(sz)
+	if err != nil || declared < 0 {
+		return nil
+	}
+	if used := (offsetBits + 7) / 8; used > declared {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("assembly %q members use %d bytes but its declared size is %d", asmName, used, declared), nil)
+	}
+	return nil
+}
+
+// paramProperties builds the ResourceProperties for a param: its value type and
+// readWrite plus the optional engineering fields (units, scale, base, offset,
+// min/max, default) mapped from the EDS [Params] entry. scale is
+// Mult ÷ Div. Fields absent or unparseable in the EDS are left unset.
+func paramProperties(p param, valueType, readWrite string) dtos.ResourceProperties {
+	props := dtos.ResourceProperties{
+		ValueType:    valueType,
+		ReadWrite:    readWrite,
+		Units:        p.units,
+		DefaultValue: strings.TrimSpace(p.defaultVal),
+		Minimum:      parseFloat(p.minimum),
+		Maximum:      parseFloat(p.maximum),
+		Base:         parseFloat(p.scaleBase),
+		Offset:       parseFloat(p.scaleOff),
+		Scale:        scaleFactor(p.scaleMult, p.scaleDiv),
+	}
+	return props
+}
+
+// parseFloat parses an EDS numeric field into a *float64, or nil if blank or
+// unparseable (the field is optional; a bad value is simply not carried).
+func parseFloat(s string) *float64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return nil
+	}
+	return &f
+}
+
+// scaleFactor computes the scale as Mult ÷ Div, or nil unless both are present
+// and Div is non-zero.
+func scaleFactor(mult, div string) *float64 {
+	m, d := parseFloat(mult), parseFloat(div)
+	if m == nil || d == nil || *d == 0 {
+		return nil
+	}
+	s := *m / *d
+	return &s
+}
+
+// nameSet allocates unique device-resource names. used records every emitted
+// name (resource names must be unique for ValidateDeviceProfileDTO); nextN
+// remembers the next numeric suffix per base so allocation stays O(1) amortised
+// rather than re-scanning on every collision.
+type nameSet struct {
+	used  map[string]bool
+	nextN map[string]int
+}
+
+func newNameSet() *nameSet {
+	return &nameSet{used: map[string]bool{}, nextN: map[string]int{}}
+}
+
+// unique returns a name not yet emitted, and records it. It tries base, then
+// base+"_"+typ (the common case: the same point in both directions, e.g.
+// Setpoint / Setpoint_T2O), then base_2, base_3… as a last resort.
+func (n *nameSet) unique(base, typ string) string {
+	if !n.used[base] {
+		n.used[base] = true
+		return base
+	}
+	if c := base + "_" + typ; !n.used[c] {
+		n.used[c] = true
+		return c
+	}
+	i := n.nextN[base]
+	if i < 2 {
+		i = 2
+	}
+	for {
+		c := base + "_" + strconv.Itoa(i)
+		i++
+		if !n.used[c] {
+			n.used[c] = true
+			n.nextN[base] = i
+			return c
+		}
+	}
+}
+
+// isPadMember reports whether a member is padding: it has no param reference, or
+// the referenced param is named with the RESERVED prefix (EDS pad convention).
+// Pads occupy offset but produce no resource. p is the member's param (zero
+// value if the ref is unknown, in which case only the empty-ref case matters).
+func isPadMember(m assemblyMember, p param) bool {
+	if m.paramRef == "" {
+		return true
+	}
+	return strings.HasPrefix(p.name, reservedPrefix)
+}
+
+// memberBitLength returns a member's bit length: the assembly's explicit member
+// size when present, else the referenced param's Data Size (bytes) in bits. The
+// length must be positive. p/hasParam are the member's looked-up param.
+func memberBitLength(m assemblyMember, p param, hasParam bool) (int, errors.EdgeX) {
+	if m.bitLength != "" {
+		n, err := strconv.Atoi(strings.TrimSpace(m.bitLength))
+		if err != nil {
+			return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("invalid bit length %q", m.bitLength), err)
+		}
+		return checkBits(n)
+	}
+	if !hasParam {
+		return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, "no bit length and no param to take a Data Size from", nil)
+	}
+	sizeBytes := strings.TrimSpace(p.dataSize)
+	if sizeBytes == "" {
+		return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, "no bit length and param has no Data Size", nil)
+	}
+	n, err := strconv.Atoi(sizeBytes)
+	if err != nil {
+		return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("invalid param Data Size %q", sizeBytes), err)
+	}
+	// Bound the byte count before multiplying so n*8 cannot overflow.
+	if n < 0 || n > maxOffsetBytes {
+		return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("param Data Size %d out of range 0-%d", n, maxOffsetBytes), nil)
+	}
+	return checkBits(n * 8)
+}
+
+// maxBitLength bounds a single member's bit length (the whole implicit I/O area
+// is at most maxOffsetBytes). It also keeps the running offset from overflowing.
+const maxBitLength = maxOffsetBytes * 8
+
+// checkBits rejects a bit length outside 1..maxBitLength. Zero/negative would
+// give a zero-length resource or a negative offset; an over-large value would
+// overflow the running offset.
+func checkBits(n int) (int, errors.EdgeX) {
+	if n <= 0 || n > maxBitLength {
+		return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("bit length %d out of range 1-%d", n, maxBitLength), nil)
+	}
+	return n, nil
+}
+
+// sanitizeName turns a product name into a lower-cased identifier, e.g.
+// "EtherNetIP Sample" -> "ethernetip-sample". EdgeX only requires a non-empty
+// name, but a clean identifier avoids surprises where the name is used as a key.
+// Non-ASCII letters are kept (lower-cased) by design — EdgeX does not restrict
+// the character set.
+func sanitizeName(s string) string {
+	// Spaces, tabs, slashes and existing hyphens are all separators; collapse
+	// any run of them to a single hyphen, then trim leading/trailing hyphens.
+	isSeparator := func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '/' || r == '\\' || r == '-'
+	}
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case isSeparator(r):
+			if !prevHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		default:
+			b.WriteRune(r)
+			prevHyphen = false
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/pkg/profileconv/eds/mapper_io_test.go
+++ b/pkg/profileconv/eds/mapper_io_test.go
@@ -1,0 +1,432 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+// resourceByName finds a resource in a slice, or fails the test.
+func resourceByName(t *testing.T, rs []dtos.DeviceResource, name string) dtos.DeviceResource {
+	t.Helper()
+	for _, r := range rs {
+		if r.Name == name {
+			return r
+		}
+	}
+	t.Fatalf("resource %q not found", name)
+	return dtos.DeviceResource{}
+}
+
+// ioWant is the expected shape of one implicit-I/O resource. bitLen 0 means the
+// bitLength attribute should be absent (Bool omits it).
+type ioWant struct {
+	typ                  string
+	offBytes, offBits    int
+	bitLen               int
+	valueType, readWrite string
+}
+
+// assertIOResource checks one resource against its expected shape.
+func assertIOResource(t *testing.T, r dtos.DeviceResource, w ioWant) {
+	t.Helper()
+	if got := r.Attributes[attrType]; got != w.typ {
+		t.Errorf("type: got %v, want %s", got, w.typ)
+	}
+	if got := r.Attributes[attrOffsetBytes]; got != w.offBytes {
+		t.Errorf("offsetBytes: got %v, want %d", got, w.offBytes)
+	}
+	if got := r.Attributes[attrOffsetBits]; got != w.offBits {
+		t.Errorf("offsetBits: got %v, want %d", got, w.offBits)
+	}
+	if w.bitLen == 0 {
+		if got, ok := r.Attributes[attrBitLength]; ok {
+			t.Errorf("bitLength: got %v, want absent", got)
+		}
+	} else if got := r.Attributes[attrBitLength]; got != w.bitLen {
+		t.Errorf("bitLength: got %v, want %d", got, w.bitLen)
+	}
+	if r.Properties.ValueType != w.valueType {
+		t.Errorf("valueType: got %s, want %s", r.Properties.ValueType, w.valueType)
+	}
+	if r.Properties.ReadWrite != w.readWrite {
+		t.Errorf("readWrite: got %s, want %s", r.Properties.ReadWrite, w.readWrite)
+	}
+}
+
+// Golden offsets from the sample's appendix. Assem100 (O2T, output/W) packs
+// three BOOLs into byte0, a 5-bit pad, then widening types; Assem101 (T2O,
+// input/R) is the read side.
+func TestMapImplicitIO_OffsetsAndDirection(t *testing.T) {
+	rs, err := extractSample(t).mapImplicitIO(newNameSet())
+	if err != nil {
+		t.Fatalf("mapImplicitIO: %v", err)
+	}
+
+	cases := map[string]ioWant{
+		// O2T output side (byte offsets from the appendix). Bool omits bitLength,
+		// matching XRT profiles.
+		"DO Channel 0":      {typeO2T, 0, 0, 0, common.ValueTypeBool, common.ReadWrite_W},
+		"DO Channel 1":      {typeO2T, 0, 1, 0, common.ValueTypeBool, common.ReadWrite_W},
+		"DO Channel 2":      {typeO2T, 0, 2, 0, common.ValueTypeBool, common.ReadWrite_W},
+		"Output SINT":       {typeO2T, 1, 0, 8, common.ValueTypeInt8, common.ReadWrite_W},
+		"Output INT scaled": {typeO2T, 2, 0, 16, common.ValueTypeInt16, common.ReadWrite_W},
+		"Output DINT":       {typeO2T, 4, 0, 32, common.ValueTypeInt32, common.ReadWrite_W},
+		"Output REAL":       {typeO2T, 8, 0, 32, common.ValueTypeFloat32, common.ReadWrite_W},
+		"Output Mode":       {typeO2T, 12, 0, 16, common.ValueTypeUint16, common.ReadWrite_W},
+		// T2O input side.
+		"Input LINT":  {typeT2O, 0, 0, 64, common.ValueTypeInt64, common.ReadWrite_R},
+		"Input USINT": {typeT2O, 24, 0, 8, common.ValueTypeUint8, common.ReadWrite_R},
+		"Input WORD":  {typeT2O, 26, 0, 16, common.ValueTypeUint16, common.ReadWrite_R},
+	}
+	for name, w := range cases {
+		t.Run(name, func(t *testing.T) {
+			assertIOResource(t, resourceByName(t, rs, name), w)
+		})
+	}
+}
+
+// Setpoint (Param24) is referenced by both Assem100 (O2T) and Assem101 (T2O).
+// Per the XRT model that is two distinct resources — an O2T (W) one and a T2O
+// (R) one — not a single RW resource. The colliding name is direction-suffixed
+// so both survive ValidateDeviceProfileDTO's uniqueness check.
+func TestMapImplicitIO_SharedParamSplitsByDirection(t *testing.T) {
+	rs, err := extractSample(t).mapImplicitIO(newNameSet())
+	if err != nil {
+		t.Fatalf("mapImplicitIO: %v", err)
+	}
+	// O2T side keeps the plain name (emitted first), W, at byte14.
+	o2t := resourceByName(t, rs, "Setpoint")
+	if o2t.Attributes[attrType] != typeO2T || o2t.Properties.ReadWrite != common.ReadWrite_W {
+		t.Errorf("Setpoint (O2T): got type=%v rw=%s, want O2T/W", o2t.Attributes[attrType], o2t.Properties.ReadWrite)
+	}
+	if o2t.Attributes[attrOffsetBytes] != 14 {
+		t.Errorf("Setpoint (O2T) offsetBytes: got %v, want 14", o2t.Attributes[attrOffsetBytes])
+	}
+	// T2O side is suffixed, R, at byte32.
+	t2o := resourceByName(t, rs, "Setpoint_T2O")
+	if t2o.Attributes[attrType] != typeT2O || t2o.Properties.ReadWrite != common.ReadWrite_R {
+		t.Errorf("Setpoint_T2O: got type=%v rw=%s, want T2O/R", t2o.Attributes[attrType], t2o.Properties.ReadWrite)
+	}
+	if t2o.Attributes[attrOffsetBytes] != 32 {
+		t.Errorf("Setpoint_T2O offsetBytes: got %v, want 32", t2o.Attributes[attrOffsetBytes])
+	}
+}
+
+// Pad members (RESERVED_*) occupy offset but must not produce a resource. (Their
+// effect on offset is asserted in TestMapImplicitIO_OffsetsAndDirection, where
+// Output SINT lands at byte1 only if the 5-bit pad filled byte0.)
+func TestMapImplicitIO_PadProducesNoResource(t *testing.T) {
+	rs, err := extractSample(t).mapImplicitIO(newNameSet())
+	if err != nil {
+		t.Fatalf("mapImplicitIO: %v", err)
+	}
+	for _, r := range rs {
+		if r.Name == "RESERVED_pad5" || r.Name == "RESERVED_pad8" {
+			t.Errorf("pad member %q produced a resource", r.Name)
+		}
+	}
+}
+
+// ioFixture builds a minimal extracted with one assembly used by n connections
+// in the given direction, so edge cases can be exercised without a sample file.
+func ioFixture(dir string, members []assemblyMember, params map[string]param, conns int) *extracted {
+	x := &extracted{
+		params:     params,
+		assemblies: map[string]assembly{"A": {name: "A", assemblyID: 100, members: members}},
+	}
+	for i := 0; i < conns; i++ {
+		c := connection{}
+		if dir == typeO2T {
+			c.o2tFormat = "A"
+		} else {
+			c.t2oFormat = "A"
+		}
+		x.connections = append(x.connections, c)
+	}
+	return x
+}
+
+// Several connections sharing one assembly must expand it once, not once
+// per connection (which would duplicate resources and mangle names).
+func TestMapImplicitIO_SharedAssemblyExpandedOnce(t *testing.T) {
+	x := ioFixture(typeO2T,
+		[]assemblyMember{{bitLength: "16", paramRef: "P1"}},
+		map[string]param{"P1": {name: "X", dataType: "0xC3"}},
+		3, // three connections all referencing assembly A as O2T
+	)
+	rs, err := x.mapImplicitIO(newNameSet())
+	if err != nil {
+		t.Fatalf("mapImplicitIO: %v", err)
+	}
+	if len(rs) != 1 {
+		t.Fatalf("shared assembly should yield 1 resource, got %d (%+v)", len(rs), rs)
+	}
+	if rs[0].Name != "X" {
+		t.Errorf("name: got %q, want X (no spurious suffix)", rs[0].Name)
+	}
+}
+
+// Names that would still collide after the direction suffix get a numeric
+// suffix so every resource name stays unique (ValidateDeviceProfileDTO requires it).
+func TestNameSetUnique(t *testing.T) {
+	n := newNameSet()
+	got := []string{
+		n.unique("X", typeO2T), // X
+		n.unique("X", typeT2O), // X_T2O
+		n.unique("X", typeT2O), // X_T2O taken -> X_2
+		n.unique("X", typeT2O), // -> X_3
+	}
+	want := []string{"X", "X_T2O", "X_2", "X_3"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("unique[%d]: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// M1: a non-positive bit length is rejected, not turned into a bad offset.
+func TestMapImplicitIO_NonPositiveBitLengthErrors(t *testing.T) {
+	for _, bits := range []string{"-8", "0"} {
+		t.Run(bits, func(t *testing.T) {
+			x := ioFixture(typeO2T,
+				[]assemblyMember{{bitLength: bits, paramRef: "P1"}},
+				map[string]param{"P1": {name: "X", dataType: "0xC3"}}, 1)
+			_, err := x.mapImplicitIO(newNameSet())
+			if err == nil {
+				t.Fatalf("expected error for bit length %q", bits)
+			}
+			if errors.Kind(err) != errors.KindContractInvalid {
+				t.Errorf("kind: got %v", errors.Kind(err))
+			}
+		})
+	}
+}
+
+// M2: a member referencing an unknown param gives an error naming the assembly
+// and the missing param, not an opaque "empty CIP data type code".
+func TestMapImplicitIO_DanglingParamRefErrors(t *testing.T) {
+	x := ioFixture(typeO2T,
+		[]assemblyMember{{bitLength: "16", paramRef: "Ghost"}},
+		map[string]param{}, 1)
+	_, err := x.mapImplicitIO(newNameSet())
+	if err == nil {
+		t.Fatal("expected error for dangling param ref")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("kind: got %v", errors.Kind(err))
+	}
+	if msg := err.Error(); !strings.Contains(msg, "Ghost") {
+		t.Errorf("error should name the missing param Ghost, got: %s", msg)
+	}
+}
+
+// Data Size fallback: a member with empty bit length takes the param's Data Size
+// (bytes) as its length; missing Data Size is an error.
+func TestMapImplicitIO_DataSizeFallback(t *testing.T) {
+	// USINT with Data Size 1 byte -> 8 bits.
+	x := ioFixture(typeT2O,
+		[]assemblyMember{{bitLength: "", paramRef: "P1"}},
+		map[string]param{"P1": {name: "In", dataType: "0xC6", dataSize: "1"}}, 1)
+	rs, err := x.mapImplicitIO(newNameSet())
+	if err != nil {
+		t.Fatalf("mapImplicitIO: %v", err)
+	}
+	if rs[0].Attributes[attrBitLength] != 8 {
+		t.Errorf("bitLength from Data Size: got %v, want 8", rs[0].Attributes[attrBitLength])
+	}
+
+	// No bit length and no Data Size -> error.
+	x = ioFixture(typeT2O,
+		[]assemblyMember{{bitLength: "", paramRef: "P1"}},
+		map[string]param{"P1": {name: "In", dataType: "0xC6"}}, 1)
+	if _, err := x.mapImplicitIO(newNameSet()); err == nil {
+		t.Error("expected error when member has neither bit length nor Data Size")
+	}
+}
+
+// A5: Bool omits bitLength; a wider type keeps it.
+func TestMapImplicitIO_BoolOmitsBitLength(t *testing.T) {
+	x := ioFixture(typeO2T,
+		[]assemblyMember{
+			{bitLength: "1", paramRef: "B"},
+			{bitLength: "16", paramRef: "I"},
+		},
+		map[string]param{
+			"B": {name: "Flag", dataType: "0xC1"}, // BOOL
+			"I": {name: "Word", dataType: "0xC3"}, // INT
+		}, 1)
+	rs, err := x.mapImplicitIO(newNameSet())
+	if err != nil {
+		t.Fatalf("mapImplicitIO: %v", err)
+	}
+	if _, ok := resourceByName(t, rs, "Flag").Attributes[attrBitLength]; ok {
+		t.Error("Bool resource should omit bitLength")
+	}
+	if resourceByName(t, rs, "Word").Attributes[attrBitLength] != 16 {
+		t.Error("non-Bool resource should keep bitLength")
+	}
+}
+
+// A single member whose bit length exceeds maxBitLength is rejected by
+// checkBits (distinct from the accumulated-offset guard exercised below).
+func TestMapImplicitIO_MemberBitLengthOverMaxErrors(t *testing.T) {
+	x := ioFixture(typeO2T,
+		[]assemblyMember{
+			{bitLength: "16016", paramRef: "PAD"}, // 16016 > maxBitLength (16000)
+		},
+		map[string]param{
+			"PAD": {name: "RESERVED_big"},
+		}, 1)
+	_, err := x.mapImplicitIO(newNameSet())
+	if err == nil {
+		t.Fatal("expected error for member bit length over max")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("kind: got %v", errors.Kind(err))
+	}
+}
+
+// An assembly with no members yields no resources and no error.
+func TestMapImplicitIO_EmptyAssembly(t *testing.T) {
+	x := ioFixture(typeO2T, nil, map[string]param{}, 1)
+	rs, err := x.mapImplicitIO(newNameSet())
+	if err != nil {
+		t.Fatalf("mapImplicitIO: %v", err)
+	}
+	if len(rs) != 0 {
+		t.Errorf("empty assembly: got %d resources, want 0", len(rs))
+	}
+}
+
+// An assembly declared in [Assembly] but referenced by no connection produces
+// nothing (no I/O resource, no Settings) and no error: only assemblies a
+// connection uses have a known direction, and EDS commonly declares extra
+// unused/alternate assemblies.
+func TestMapImplicitIO_UnreferencedAssemblyIgnored(t *testing.T) {
+	x := &extracted{
+		params: map[string]param{"P": {name: "Used", dataType: "0xC2"}},
+		assemblies: map[string]assembly{
+			"Used":   {name: "Used", assemblyID: 100, members: []assemblyMember{{bitLength: "8", paramRef: "P"}}},
+			"Unused": {name: "Unused", assemblyID: 200, members: []assemblyMember{{bitLength: "8", paramRef: "P"}}},
+		},
+		connections: []connection{{o2tFormat: "Used"}}, // Unused not referenced
+	}
+
+	io, err := x.mapImplicitIO(newNameSet())
+	if err != nil {
+		t.Fatalf("mapImplicitIO: %v", err)
+	}
+	if len(io) != 1 || io[0].Name != "Used" {
+		t.Errorf("I/O resources: got %+v, want only the referenced assembly's member", io)
+	}
+
+	set, err := x.mapSettings(newNameSet())
+	if err != nil {
+		t.Fatalf("mapSettings: %v", err)
+	}
+	// Only the referenced assembly yields a Settings resource; none carries the
+	// unreferenced assembly's id (200).
+	for _, r := range set {
+		if r.Attributes[attrAssemblyID] == 200 {
+			t.Errorf("unreferenced assembly 200 leaked into settings: %+v", r)
+		}
+	}
+	if len(set) != 1 {
+		t.Errorf("settings: got %d, want 1 (only the referenced O2T assembly)", len(set))
+	}
+}
+
+// Scaling / min / max / default from [Params] map into properties;
+// scale = Mult ÷ Div. A resource with no such fields carries none.
+func TestMapImplicitIO_ScalingProperties(t *testing.T) {
+	rs, err := extractSample(t).mapImplicitIO(newNameSet())
+	if err != nil {
+		t.Fatalf("mapImplicitIO: %v", err)
+	}
+	scaled := resourceByName(t, rs, "Output INT scaled")
+	if scaled.Properties.Scale == nil || *scaled.Properties.Scale != 0.1 {
+		t.Errorf("scale: got %v, want 0.1", scaled.Properties.Scale)
+	}
+	if scaled.Properties.Minimum == nil || *scaled.Properties.Minimum != -3200 {
+		t.Errorf("minimum: got %v, want -3200", scaled.Properties.Minimum)
+	}
+	if scaled.Properties.Maximum == nil || *scaled.Properties.Maximum != 3200 {
+		t.Errorf("maximum: got %v, want 3200", scaled.Properties.Maximum)
+	}
+	// A plain BOOL output carries no scaling/min/max.
+	do0 := resourceByName(t, rs, "DO Channel 0")
+	if do0.Properties.Scale != nil || do0.Properties.Minimum != nil {
+		t.Errorf("DO0 should have no scale/min, got scale=%v min=%v", do0.Properties.Scale, do0.Properties.Minimum)
+	}
+}
+
+// A member bit length or Data Size beyond the max is rejected, not overflowed
+// into a bogus small value.
+func TestMapImplicitIO_OversizeBitLengthErrors(t *testing.T) {
+	cases := map[string]*extracted{
+		"huge bitLength": ioFixture(typeO2T,
+			[]assemblyMember{{bitLength: "9223372036854775807", paramRef: "P1"}},
+			map[string]param{"P1": {name: "X", dataType: "0xC3"}}, 1),
+		"huge Data Size": ioFixture(typeO2T,
+			[]assemblyMember{{bitLength: "", paramRef: "P1"}},
+			map[string]param{"P1": {name: "X", dataType: "0xC3", dataSize: "2305843009213693953"}}, 1),
+	}
+	for name, x := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := x.mapImplicitIO(newNameSet()); err == nil {
+				t.Fatal("expected error for oversize bit length / Data Size")
+			}
+		})
+	}
+}
+
+// A member with no param reference is a pad: it advances the offset (so the
+// next member lands past it) but yields no resource. This is the empty-ref pad
+// path, distinct from a RESERVED-named param.
+func TestMapImplicitIO_EmptyRefPad(t *testing.T) {
+	x := ioFixture(typeO2T,
+		[]assemblyMember{
+			{bitLength: "8", paramRef: ""},    // pad, no ref
+			{bitLength: "16", paramRef: "P1"}, // must land at byte1
+		},
+		map[string]param{"P1": {name: "X", dataType: "0xC3"}}, 1)
+	rs, err := x.mapImplicitIO(newNameSet())
+	if err != nil {
+		t.Fatalf("mapImplicitIO: %v", err)
+	}
+	if len(rs) != 1 {
+		t.Fatalf("empty-ref pad should yield 1 resource, got %d", len(rs))
+	}
+	if rs[0].Name != "X" || rs[0].Attributes[attrOffsetBytes] != 1 {
+		t.Errorf("member after pad: got %q byte=%v, want X byte1", rs[0].Name, rs[0].Attributes[attrOffsetBytes])
+	}
+}
+
+// The running offset is bounded: members accumulating past maxOffsetBytes are
+// rejected (the per-member bit length is individually within limits).
+func TestMapImplicitIO_OffsetOverMaxErrors(t *testing.T) {
+	x := ioFixture(typeO2T,
+		[]assemblyMember{
+			{bitLength: "16000", paramRef: "P1"}, // 2000 bytes
+			{bitLength: "16", paramRef: "P2"},    // reaches byte 2002
+			{bitLength: "16", paramRef: "P3"},    // starts at offsetBytes 2002 > 2000
+		},
+		map[string]param{
+			"P1": {name: "A", dataType: "0xC3"},
+			"P2": {name: "B", dataType: "0xC3"},
+			"P3": {name: "C", dataType: "0xC3"},
+		}, 1)
+	_, err := x.mapImplicitIO(newNameSet())
+	if err == nil {
+		t.Fatal("expected error when accumulated offset exceeds max")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("kind: got %v", errors.Kind(err))
+	}
+}

--- a/pkg/profileconv/eds/mapper_test.go
+++ b/pkg/profileconv/eds/mapper_test.go
@@ -1,0 +1,215 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+func TestSanitizeName(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"EtherNetIP Sample", "ethernetip-sample"},
+		{"DEMO-DIO8", "demo-dio8"}, // already an identifier
+		{"AB/1756 Module", "ab-1756-module"},
+		{"  spaced  ", "spaced"},       // leading/trailing separators trimmed
+		{"a//b  c", "a-b-c"},           // runs of separators collapse to one
+		{"Back\\slash", "back-slash"},  // backslash is a separator
+		{"a - b", "a-b"},               // space+hyphen+space collapses, not "a---b"
+		{"a---b", "a-b"},               // existing hyphen run collapses too
+		{"/lead/trail/", "lead-trail"}, // leading/trailing slashes trimmed
+		{"\ttab\t", "tab"},             // tab is a separator
+		{"   ", ""},                    // all-whitespace sanitizes to empty
+		{"///", ""},                    // all-separator sanitizes to empty
+		{"", ""},                       // empty stays empty (caller handles)
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := sanitizeName(tt.in); got != tt.want {
+				t.Errorf("sanitizeName(%q): got %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapToProfileIdentity(t *testing.T) {
+	x := extractSample(t)
+	p, err := x.mapToProfile()
+	if err != nil {
+		t.Fatalf("mapToProfile: %v", err)
+	}
+	if p.Name != "ethernetip-sample" {
+		t.Errorf("Name: got %q, want ethernetip-sample", p.Name)
+	}
+	if p.Manufacturer != "Coverage Test Vendor" {
+		t.Errorf("Manufacturer: got %q", p.Manufacturer)
+	}
+	if p.Model != "EtherNetIP Sample" {
+		t.Errorf("Model: got %q, want EtherNetIP Sample (original, not sanitized)", p.Model)
+	}
+}
+
+// model/name fall back to Catalog when ProdName is absent OR sanitizes to empty
+// (e.g. whitespace-only) — the fallback keys off the sanitized result, not the
+// raw string, so a whitespace ProdName does not shadow a usable Catalog.
+func TestMapToProfileCatalogFallback(t *testing.T) {
+	tests := []struct {
+		name        string
+		productName string
+	}{
+		{"prodname absent", ""},
+		{"prodname whitespace", "   "}, // must still fall back to Catalog
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := (&extracted{device: deviceInfo{productName: tt.productName, catalog: "Fallback Cat"}}).mapToProfile()
+			if err != nil {
+				t.Fatalf("mapToProfile: %v", err)
+			}
+			if p.Model != "Fallback Cat" || p.Name != "fallback-cat" {
+				t.Errorf("catalog fallback: got model=%q name=%q", p.Model, p.Name)
+			}
+			if p.Manufacturer != "" {
+				t.Errorf("Manufacturer should be empty, got %q", p.Manufacturer)
+			}
+		})
+	}
+}
+
+// No ProdName and no Catalog means no derivable name — an error, not an empty name.
+func TestMapToProfileNoNameErrors(t *testing.T) {
+	_, err := (&extracted{}).mapToProfile()
+	if err == nil {
+		t.Fatal("expected error when device has no ProdName/Catalog")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+	}
+}
+
+// An enumerated I/O param becomes a DeviceCommand whose single resourceOperation
+// carries the value->label mappings and targets the emitted resource. A param
+// without an enum produces no command.
+func TestMapToProfileEnumCommand(t *testing.T) {
+	x := ioFixture(typeO2T,
+		[]assemblyMember{
+			{bitLength: "16", paramRef: "Mode"},
+			{bitLength: "8", paramRef: "Plain"},
+		},
+		map[string]param{
+			"Mode":  {name: "Mode", dataType: "0xC7", enum: map[string]string{"0": "Off", "1": "On"}},
+			"Plain": {name: "Plain", dataType: "0xC2"},
+		}, 1)
+	x.device = deviceInfo{productName: "Dev"}
+
+	p, err := x.mapToProfile()
+	if err != nil {
+		t.Fatalf("mapToProfile: %v", err)
+	}
+	if len(p.DeviceCommands) != 1 {
+		t.Fatalf("device commands: got %d, want 1 (only the enum param)", len(p.DeviceCommands))
+	}
+	cmd := p.DeviceCommands[0]
+	if cmd.Name != "Mode" || cmd.ReadWrite != common.ReadWrite_W {
+		t.Errorf("command: got name=%q rw=%q, want Mode/W", cmd.Name, cmd.ReadWrite)
+	}
+	if len(cmd.ResourceOperations) != 1 || cmd.ResourceOperations[0].DeviceResource != "Mode" {
+		t.Fatalf("resourceOperations: got %+v", cmd.ResourceOperations)
+	}
+	m := cmd.ResourceOperations[0].Mappings
+	if m["0"] != "Off" || m["1"] != "On" || len(m) != 2 {
+		t.Errorf("mappings: got %v, want {0:Off, 1:On}", m)
+	}
+}
+
+// A bidirectional enum param (in both an O2T and a T2O assembly) becomes TWO
+// resources (X and X_T2O) and TWO commands, each targeting its emitted
+// (direction-suffixed) resource name. This locks the invariant that the command
+// tracks the FINAL resource name, not the raw param name — using the param name
+// would emit two commands both named X, which profile.Validate() rejects as a
+// duplicate/dangling command.
+func TestMapToProfileBidirectionalEnumCommands(t *testing.T) {
+	x := &extracted{
+		params: map[string]param{
+			"Mode": {name: "Mode", dataType: "0xC7", enum: map[string]string{"0": "Off", "1": "On"}},
+		},
+		assemblies: map[string]assembly{
+			"Out": {name: "Out", assemblyID: 100, members: []assemblyMember{{bitLength: "16", paramRef: "Mode"}}},
+			"In":  {name: "In", assemblyID: 101, members: []assemblyMember{{bitLength: "16", paramRef: "Mode"}}},
+		},
+		connections: []connection{{o2tFormat: "Out", t2oFormat: "In"}},
+		device:      deviceInfo{productName: "Dev"},
+	}
+	p, err := x.mapToProfile()
+	if err != nil {
+		t.Fatalf("mapToProfile: %v", err)
+	}
+	// Must pass EdgeX validation: two distinctly-named commands, each referencing
+	// a resource that exists.
+	if verr := p.Validate(); verr != nil {
+		t.Fatalf("validation: %v", verr)
+	}
+	if len(p.DeviceCommands) != 2 {
+		t.Fatalf("device commands: got %d, want 2 (O2T + T2O)", len(p.DeviceCommands))
+	}
+	// Command name -> (readWrite, target resource); both must be self-consistent
+	// and distinct.
+	byName := map[string]dtos.DeviceCommand{}
+	for _, c := range p.DeviceCommands {
+		byName[c.Name] = c
+	}
+	for name, wantRW := range map[string]string{"Mode": common.ReadWrite_W, "Mode_T2O": common.ReadWrite_R} {
+		c, ok := byName[name]
+		if !ok {
+			t.Fatalf("missing command %q; got %v", name, byName)
+		}
+		if c.ReadWrite != wantRW {
+			t.Errorf("%s readWrite: got %q, want %q", name, c.ReadWrite, wantRW)
+		}
+		if c.ResourceOperations[0].DeviceResource != name {
+			t.Errorf("%s targets %q, want itself", name, c.ResourceOperations[0].DeviceResource)
+		}
+	}
+}
+
+// Mapping the same *extracted twice must be idempotent: enum scratch is per-pass,
+// so the second profile has the same commands and still validates (no duplicate).
+func TestMapToProfileIdempotent(t *testing.T) {
+	x := ioFixture(typeO2T,
+		[]assemblyMember{{bitLength: "16", paramRef: "Mode"}},
+		map[string]param{"Mode": {name: "Mode", dataType: "0xC7", enum: map[string]string{"0": "Off"}}}, 1)
+	x.device = deviceInfo{productName: "Dev"}
+
+	first, err := x.mapToProfile()
+	if err != nil {
+		t.Fatalf("first mapToProfile: %v", err)
+	}
+	second, err := x.mapToProfile()
+	if err != nil {
+		t.Fatalf("second mapToProfile: %v", err)
+	}
+	if len(first.DeviceCommands) != 1 || len(second.DeviceCommands) != 1 {
+		t.Fatalf("commands: first=%d second=%d, want 1 each", len(first.DeviceCommands), len(second.DeviceCommands))
+	}
+	if verr := second.Validate(); verr != nil {
+		t.Errorf("second profile failed validation (duplicate command?): %v", verr)
+	}
+}
+
+// A profile with no enum params omits deviceCommands (nil), not an empty slice.
+func TestMapToProfileNoEnumNoCommands(t *testing.T) {
+	x := ioFixture(typeO2T,
+		[]assemblyMember{{bitLength: "8", paramRef: "P"}},
+		map[string]param{"P": {name: "P", dataType: "0xC2"}}, 1)
+	x.device = deviceInfo{productName: "Dev"}
+	p, err := x.mapToProfile()
+	if err != nil {
+		t.Fatalf("mapToProfile: %v", err)
+	}
+	if p.DeviceCommands != nil {
+		t.Errorf("deviceCommands: got %v, want nil", p.DeviceCommands)
+	}
+}

--- a/pkg/profileconv/eds/mappersettings.go
+++ b/pkg/profileconv/eds/mappersettings.go
@@ -1,0 +1,182 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+const (
+	// XRT Settings value bounds.
+	maxAssemblyID = 65535
+	maxIOSize     = 2000 // O2T / T2O assembly size (bytes)
+	maxConfigSize = 400  // Config assembly size (bytes)
+
+	// A Settings resource carries no data value, but EdgeX requires valueType and
+	// readWrite; these placeholders match what XRT profiles use.
+	settingsValueType = common.ValueTypeString
+	settingsReadWrite = common.ReadWrite_R
+
+	// Header-format field values in the connection-parameters DWORD:
+	// 4 = 4-byte run/idle header.
+	headerRunIdle        = 4
+	o2tHeaderFormatShift = 8  // bits 8-10
+	t2oHeaderFormatShift = 12 // bits 12-14
+	headerFormatMask     = 0x7
+)
+
+// mapSettings builds one Settings resource per assembly a connection
+// uses: O2TSettings / T2OSettings / ConfigSettings. This is the "1 Settings + N
+// I/O" fan-out. Each (assembly, settings-type) pair is emitted once even if
+// several connections share the assembly.
+func (x *extracted) mapSettings(names *nameSet) ([]dtos.DeviceResource, errors.EdgeX) {
+	var resources []dtos.DeviceResource
+	// header32 of each (assembly, settings-type) already emitted, so a shared
+	// assembly is emitted once and a conflicting header across connections is
+	// caught rather than silently taking the first.
+	done := map[string]bool{}
+
+	for _, c := range x.connections {
+		for _, s := range settingsRefs(c) {
+			if s.asmName == "" {
+				continue
+			}
+			skip, err := seenSettings(done, s)
+			if err != nil {
+				return nil, err
+			}
+			if skip {
+				continue
+			}
+
+			r, err := x.buildSettingsResource(s, names)
+			if err != nil {
+				return nil, err
+			}
+			resources = append(resources, r)
+		}
+	}
+	return resources, nil
+}
+
+// seenSettings records the (assembly, settings-type) target in done and reports
+// whether it was already emitted (skip=true). A shared assembly whose header32
+// differs across connections is a conflict error, not a silent first-wins.
+func seenSettings(done map[string]bool, s settingsRef) (skip bool, err errors.EdgeX) {
+	key := s.asmName + "/" + s.settType
+	if prev, ok := done[key]; ok {
+		if prev != s.header32 {
+			return false, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("assembly %q is used by connections with conflicting %s", s.asmName, attrIncludeHeader32bit), nil)
+		}
+		return true, nil
+	}
+	done[key] = s.header32
+	return false, nil
+}
+
+// settingsRef is one (assembly, settings-type) target derived from a connection.
+type settingsRef struct {
+	asmName  string
+	settType string
+	header32 bool
+}
+
+// settingsRefs expands a connection into its O2T/T2O/Config settings targets.
+func settingsRefs(c connection) []settingsRef {
+	o2tHdr, t2oHdr := connectionHeader32bit(c.connectionParams)
+	return []settingsRef{
+		{c.o2tFormat, typeO2TSettings, o2tHdr},
+		{c.t2oFormat, typeT2OSettings, t2oHdr},
+		{asmName: c.configFormat, settType: typeConfigSettings}, // config has no header
+	}
+}
+
+// buildSettingsResource builds the Settings resource for one target: it resolves
+// the assembly, bounds-checks its id/size, and assembles the attributes.
+func (x *extracted) buildSettingsResource(s settingsRef, names *nameSet) (dtos.DeviceResource, errors.EdgeX) {
+	asm, aerr := x.assemblyByName(s.asmName)
+	if aerr != nil {
+		return dtos.DeviceResource{}, aerr
+	}
+	if asm.assemblyID < 0 || asm.assemblyID > maxAssemblyID {
+		return dtos.DeviceResource{}, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("assembly %q assemblyID %d out of range 0-%d", s.asmName, asm.assemblyID, maxAssemblyID), nil)
+	}
+	sizeMax := maxIOSize
+	if s.settType == typeConfigSettings {
+		sizeMax = maxConfigSize
+	}
+	size, err := parseAssemblySize(asm, sizeMax)
+	if err != nil {
+		return dtos.DeviceResource{}, err
+	}
+
+	attrs := map[string]any{
+		attrType:       s.settType,
+		attrAssemblyID: asm.assemblyID,
+		attrSize:       size,
+	}
+	if s.settType != typeConfigSettings { // only O2T/T2O carry the header flag
+		attrs[attrIncludeHeader32bit] = s.header32
+	}
+	return dtos.DeviceResource{
+		Name:        names.unique(settingsName(asm, s.settType), s.settType),
+		Description: asm.name,
+		Attributes:  attrs,
+		Properties: dtos.ResourceProperties{
+			ValueType: settingsValueType,
+			ReadWrite: settingsReadWrite,
+		},
+	}, nil
+}
+
+// connectionHeader32bit decodes the O2T and T2O includeHeader32bit flags from the
+// connection-parameters DWORD (field 1). The O2T header format is bits 8-10 and
+// the T2O header format bits 12-14; a value of 4 means a 4-byte run/idle header.
+// A blank or unparseable field defaults to false.
+func connectionHeader32bit(params string) (o2t, t2o bool) {
+	s := strings.TrimSpace(params)
+	if s == "" {
+		return false, false
+	}
+	v, err := strconv.ParseUint(s, 0, 32)
+	if err != nil {
+		return false, false
+	}
+	o2t = (v>>o2tHeaderFormatShift)&headerFormatMask == headerRunIdle
+	t2o = (v>>t2oHeaderFormatShift)&headerFormatMask == headerRunIdle
+	return o2t, t2o
+}
+
+// settingsName derives a readable Settings resource name from the assembly name,
+// falling back to "Assembly<id> <type>" when the assembly is unnamed so the name
+// still traces back to a specific assembly.
+func settingsName(asm assembly, settType string) string {
+	if asm.name != "" {
+		return asm.name + " " + settType
+	}
+	return fmt.Sprintf("Assembly%d %s", asm.assemblyID, settType)
+}
+
+// parseAssemblySize parses an assembly's declared Size (bytes). An empty size is
+// 0 (some assemblies declare no fixed size); a negative, non-numeric, or over-max
+// size is an error. max is the settings-type-specific upper bound.
+func parseAssemblySize(asm assembly, max int) (int, errors.EdgeX) {
+	s := strings.TrimSpace(asm.size)
+	if s == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("invalid assembly size %q", asm.size), err)
+	}
+	if n < 0 || n > max {
+		return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("assembly size %d out of range 0-%d", n, max), nil)
+	}
+	return n, nil
+}

--- a/pkg/profileconv/eds/mappersettings_test.go
+++ b/pkg/profileconv/eds/mappersettings_test.go
@@ -1,0 +1,346 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+// settingsByType returns the single resource with the given Settings type.
+func settingsByType(t *testing.T, rs []dtos.DeviceResource, typ string) dtos.DeviceResource {
+	t.Helper()
+	for _, r := range rs {
+		if r.Attributes[attrType] == typ {
+			return r
+		}
+	}
+	t.Fatalf("no resource with type %q", typ)
+	return dtos.DeviceResource{}
+}
+
+func TestConnectionHeader32bit(t *testing.T) {
+	tests := []struct {
+		params   string
+		o2t, t2o bool
+	}{
+		// Sample: O2T header format (bits 8-10) = 4 -> true; T2O (bits 12-14) = 0.
+		{"0x44640405", true, false},
+		{"0x44240405", true, false}, // ATI real EDS: same
+		{"0x00004000", false, true}, // T2O (bits 12-14) = 4 only -> t2o true, o2t false
+		{"0x00004400", true, true},  // both nibbles = 4 -> both true
+		{"", false, false},          // blank -> both false
+		{"nothex", false, false},    // unparseable -> both false
+	}
+	for _, tt := range tests {
+		t.Run(tt.params, func(t *testing.T) {
+			o2t, t2o := connectionHeader32bit(tt.params)
+			if o2t != tt.o2t || t2o != tt.t2o {
+				t.Errorf("got o2t=%v t2o=%v, want %v/%v", o2t, t2o, tt.o2t, tt.t2o)
+			}
+		})
+	}
+}
+
+func TestMapSettings(t *testing.T) {
+	rs, err := extractSample(t).mapSettings(newNameSet())
+	if err != nil {
+		t.Fatalf("mapSettings: %v", err)
+	}
+
+	// One Settings per used assembly: O2T (Assem100), T2O (Assem101), Config
+	// (Assem110). Find each by its type attribute.
+	byType := map[string]int{}
+	for _, r := range rs {
+		typ, _ := r.Attributes[attrType].(string)
+		byType[typ]++
+	}
+	for _, typ := range []string{typeO2TSettings, typeT2OSettings, typeConfigSettings} {
+		if byType[typ] != 1 {
+			t.Errorf("%s: got %d resources, want 1", typ, byType[typ])
+		}
+	}
+
+	// O2T Settings: assemblyID 100, size 16, includeHeader32bit true (from
+	// connection params 0x44640405 bits 8-10 = 4). Placeholder value type/RW.
+	o2t := settingsByType(t, rs, typeO2TSettings)
+	if o2t.Name != "Output Assembly O2TSettings" {
+		t.Errorf("O2T name: got %q, want %q", o2t.Name, "Output Assembly O2TSettings")
+	}
+	if o2t.Attributes[attrAssemblyID] != 100 {
+		t.Errorf("O2T assemblyID: got %v, want 100", o2t.Attributes[attrAssemblyID])
+	}
+	if o2t.Attributes[attrSize] != 16 {
+		t.Errorf("O2T size: got %v, want 16", o2t.Attributes[attrSize])
+	}
+	if o2t.Attributes[attrIncludeHeader32bit] != true {
+		t.Errorf("O2T includeHeader32bit: got %v, want true", o2t.Attributes[attrIncludeHeader32bit])
+	}
+	if o2t.Properties.ValueType != common.ValueTypeString || o2t.Properties.ReadWrite != common.ReadWrite_R {
+		t.Errorf("O2T placeholder props: got %s/%s, want String/R", o2t.Properties.ValueType, o2t.Properties.ReadWrite)
+	}
+
+	// T2O Settings: includeHeader32bit false (bits 12-14 = 0).
+	t2o := settingsByType(t, rs, typeT2OSettings)
+	if t2o.Attributes[attrIncludeHeader32bit] != false {
+		t.Errorf("T2O includeHeader32bit: got %v, want false", t2o.Attributes[attrIncludeHeader32bit])
+	}
+
+	// Config Settings carries no includeHeader32bit.
+	cfg := settingsByType(t, rs, typeConfigSettings)
+	if _, ok := cfg.Attributes[attrIncludeHeader32bit]; ok {
+		t.Error("ConfigSettings should not have includeHeader32bit")
+	}
+	if cfg.Attributes[attrAssemblyID] != 110 {
+		t.Errorf("Config assemblyID: got %v, want 110", cfg.Attributes[attrAssemblyID])
+	}
+}
+
+// assertLinkPathAttrs decodes path and checks the objClass/instID and the
+// optional attrID (hasAttr=false means the attribute segment must be absent).
+func assertLinkPathAttrs(t *testing.T, path string, objClass, instID, attrID int, hasAttr bool) {
+	t.Helper()
+	attrs, err := explicitAttrsFromLinkPath(path)
+	if err != nil {
+		t.Fatalf("explicitAttrsFromLinkPath: %v", err)
+	}
+	if attrs[attrObjClass] != objClass {
+		t.Errorf("objClass: got %v, want %d", attrs[attrObjClass], objClass)
+	}
+	if attrs[attrInstID] != instID {
+		t.Errorf("instID: got %v, want %d", attrs[attrInstID], instID)
+	}
+	if _, ok := attrs[attrAttrID]; ok != hasAttr {
+		t.Errorf("attrID present: got %v, want %v", ok, hasAttr)
+	}
+	if hasAttr && attrs[attrAttrID] != attrID {
+		t.Errorf("attrID: got %v, want %d", attrs[attrAttrID], attrID)
+	}
+}
+
+func TestExplicitAttrsFromLinkPath(t *testing.T) {
+	tests := []struct {
+		path                     string
+		objClass, instID, attrID int
+		hasAttr                  bool
+	}{
+		{"20 01 24 01 30 07", 1, 1, 7, true},    // Identity/1/ProductName
+		{"20 67 24 01 30 01", 0x67, 1, 1, true}, // vendor obj 0x67
+		{"20 01 24 01", 1, 1, 0, false},         // no attribute segment
+		{`"20 01 24 01 30 06"`, 1, 1, 6, true},  // quoted as in EDS
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assertLinkPathAttrs(t, tt.path, tt.objClass, tt.instID, tt.attrID, tt.hasAttr)
+		})
+	}
+}
+
+func TestExplicitAttrsFromLinkPathErrors(t *testing.T) {
+	// All malformed paths must error as KindContractInvalid, not silently
+	// truncate or overwrite.
+	paths := []string{
+		"30 06",             // missing class and instance
+		"20 01",             // missing instance
+		"nothex hex",        // bad byte
+		"",                  // empty
+		"20 01 24 01 30",    // odd token count: attribute value missing
+		"20 01 20 02 24 01", // duplicate class segment
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			_, err := explicitAttrsFromLinkPath(path)
+			if err == nil {
+				t.Fatalf("expected error for %q", path)
+			}
+			if errors.Kind(err) != errors.KindContractInvalid {
+				t.Errorf("kind: got %v", errors.Kind(err))
+			}
+		})
+	}
+}
+
+// A 16-bit instance segment (0x25) is now decoded by the shared parseEPATH
+// walker, so an explicit Link Path with a class >= 256 works.
+func TestExplicitAttrsFromLinkPath16Bit(t *testing.T) {
+	attrs, err := explicitAttrsFromLinkPath("21 00 00 01 24 01 30 06") // 16-bit class 0x0100: pad 00, then 00 01 LE
+	if err != nil {
+		t.Fatalf("explicitAttrsFromLinkPath: %v", err)
+	}
+	if attrs[attrObjClass] != 256 {
+		t.Errorf("objClass: got %v, want 256", attrs[attrObjClass])
+	}
+}
+
+// A shared assembly used by connections with conflicting includeHeader32bit is
+// an error, not a silent first-wins.
+func TestMapSettingsConflictingHeaderErrors(t *testing.T) {
+	x := &extracted{
+		assemblies: map[string]assembly{"A": {name: "Out", assemblyID: 100, size: "2"}},
+		connections: []connection{
+			{connectionParams: "0x400", o2tFormat: "A"}, // bits 8-10 = 4 -> true
+			{connectionParams: "0x0", o2tFormat: "A"},   // -> false
+		},
+	}
+	_, err := x.mapSettings(newNameSet())
+	if err == nil {
+		t.Fatal("expected error for conflicting includeHeader32bit")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("kind: got %v", errors.Kind(err))
+	}
+}
+
+func TestMapSettingsSizeAndAssemblyErrors(t *testing.T) {
+	// Negative size is rejected.
+	neg := &extracted{
+		assemblies:  map[string]assembly{"A": {assemblyID: 1, size: "-4"}},
+		connections: []connection{{o2tFormat: "A"}},
+	}
+	if _, err := neg.mapSettings(newNameSet()); err == nil {
+		t.Error("expected error for negative assembly size")
+	}
+	// Connection referencing an unknown assembly is rejected.
+	unknown := &extracted{
+		assemblies:  map[string]assembly{},
+		connections: []connection{{o2tFormat: "Ghost"}},
+	}
+	if _, err := unknown.mapSettings(newNameSet()); err == nil {
+		t.Error("expected error for unknown assembly")
+	}
+}
+
+// assemblyID and size bounds. Config size cap (400) is tighter than the
+// O2T/T2O cap (2000), so a size valid for I/O can be invalid for Config.
+func TestMapSettingsValueBounds(t *testing.T) {
+	settings := func(dir, size string, id int) errors.EdgeX {
+		x := &extracted{
+			assemblies: map[string]assembly{"A": {assemblyID: id, size: size}},
+		}
+		c := connection{}
+		switch dir {
+		case typeO2TSettings:
+			c.o2tFormat = "A"
+		case typeConfigSettings:
+			c.configFormat = "A"
+		}
+		x.connections = []connection{c}
+		_, err := x.mapSettings(newNameSet())
+		return err
+	}
+	// assemblyID: the cap itself is accepted, one over is rejected (guards use
+	// strict ">", so pin both sides against a ">="/off-by-one regression).
+	if err := settings(typeO2TSettings, "2", 65535); err != nil {
+		t.Errorf("assemblyID 65535 should be valid: %v", err)
+	}
+	if settings(typeO2TSettings, "2", 65536) == nil {
+		t.Error("expected error for assemblyID > 65535")
+	}
+	// Config size cap (400): exact cap accepted, one over rejected.
+	if err := settings(typeConfigSettings, "400", 1); err != nil {
+		t.Errorf("Config size 400 should be valid: %v", err)
+	}
+	if settings(typeConfigSettings, "401", 1) == nil {
+		t.Error("expected error for Config size 401 (> 400)")
+	}
+	// size 500 is fine for O2T (<=2000) but too big for Config (<=400).
+	if err := settings(typeO2TSettings, "500", 1); err != nil {
+		t.Errorf("O2T size 500 should be valid: %v", err)
+	}
+	if settings(typeConfigSettings, "500", 1) == nil {
+		t.Error("expected error for Config size 500 (> 400)")
+	}
+	// O2T/T2O size cap (2000): exact cap accepted, one over rejected.
+	if err := settings(typeO2TSettings, "2000", 1); err != nil {
+		t.Errorf("O2T size 2000 should be valid: %v", err)
+	}
+	if settings(typeO2TSettings, "2001", 1) == nil {
+		t.Error("expected error for O2T size 2001 (> 2000)")
+	}
+}
+
+func TestMapExplicit(t *testing.T) {
+	rs, err := extractSample(t).mapExplicit(newNameSet())
+	if err != nil {
+		t.Fatalf("mapExplicit: %v", err)
+	}
+	// The sample has four explicit params (Param20-23), all read-only.
+	if len(rs) != 4 {
+		t.Fatalf("explicit resources: got %d, want 4", len(rs))
+	}
+	// SerialNumber (Param23, Link Path 20 01 24 01 30 06) -> objClass 1/inst 1/attr 6.
+	sn := resourceByName(t, rs, "SerialNumber (explicit)")
+	if sn.Attributes[attrObjClass] != 1 || sn.Attributes[attrInstID] != 1 || sn.Attributes[attrAttrID] != 6 {
+		t.Errorf("SerialNumber attrs: got %v", sn.Attributes)
+	}
+	if _, ok := sn.Attributes[attrType]; ok {
+		t.Error("explicit resource must not have a type attribute")
+	}
+	if sn.Properties.ReadWrite != common.ReadWrite_R {
+		t.Errorf("explicit readWrite: got %s, want R", sn.Properties.ReadWrite)
+	}
+}
+
+// End-to-end: the full sample converts to a profile that passes EdgeX validation
+// and carries all three resource kinds (implicit I/O, settings, explicit).
+func TestConvertSampleProducesAllKinds(t *testing.T) {
+	p, err := extractSample(t).mapToProfile()
+	if err != nil {
+		t.Fatalf("mapToProfile: %v", err)
+	}
+	if verr := dtos.ValidateDeviceProfileDTO(p); verr != nil {
+		t.Fatalf("validation: %v", verr)
+	}
+	var io, settings, explicit int
+	for _, r := range p.DeviceResources {
+		typ, _ := r.Attributes[attrType].(string)
+		switch typ {
+		case typeO2T, typeT2O:
+			io++
+		case typeO2TSettings, typeT2OSettings, typeConfigSettings:
+			settings++
+		case "":
+			explicit++
+		}
+	}
+	if io == 0 || settings != 3 || explicit != 4 {
+		t.Errorf("resource kinds: io=%d settings=%d explicit=%d, want io>0 settings=3 explicit=4", io, settings, explicit)
+	}
+}
+
+// M2: an explicit param with an unsupported data type errors with the param
+// name in the message (parity with the implicit path's diagnostics).
+func TestMapExplicitErrorNamesParam(t *testing.T) {
+	x := &extracted{
+		params: map[string]param{
+			"Param9": {name: "Bad", dataType: "0xDC", linkPath: "20 01 24 01 30 06"}, // EPATH type, unsupported
+		},
+	}
+	_, err := x.mapExplicit(newNameSet())
+	if err == nil {
+		t.Fatal("expected error for unsupported explicit data type")
+	}
+	if !strings.Contains(err.Error(), "Param9") {
+		t.Errorf("error should name the param, got: %s", err.Error())
+	}
+}
+
+// M4: assembly members that overrun the declared Size are rejected.
+func TestMapImplicitSizeOverrunErrors(t *testing.T) {
+	x := ioFixture(typeO2T,
+		[]assemblyMember{{bitLength: "32", paramRef: "P1"}}, // 4 bytes
+		map[string]param{"P1": {name: "X", dataType: "0xC4"}}, 1)
+	x.assemblies["A"] = assembly{name: "A", assemblyID: 100, size: "2", // declared 2 < used 4
+		members: x.assemblies["A"].members}
+	_, err := x.mapImplicitIO(newNameSet())
+	if err == nil {
+		t.Fatal("expected error when members overrun declared size")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("kind: got %v", errors.Kind(err))
+	}
+}

--- a/pkg/profileconv/eds/modular_test.go
+++ b/pkg/profileconv/eds/modular_test.go
@@ -1,0 +1,108 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+)
+
+// A minimal modular adapter EDS: identity + a fixed status assembly (kept) + two
+// ProxyConnect entries and a [Modular] section (the dynamic-I/O markers). Mirrors
+// the shape of a real POINT I/O adapter without shipping a vendor EDS file.
+const modularAdapterEDS = `
+[Device]
+    VendName = "Demo Corp";
+    ProdName = "DEMO-AENT";
+
+[Params]
+    Param1 = 0,,,0x0000,0xC6,1,"Module Count";
+    Param2 = 0,,,0x0000,0xC6,1,"Adapter Status";
+
+[Assembly]
+    Assem1 =
+        "Adapter Status Assembly",
+        "20 04 24 01 30 03",
+        2, 0x0000, , ,
+        8, Param1,
+        8, Param2;
+
+[Connection Manager]
+    Connection1 =
+        0x02010002, 0x44240305,
+        , 2, ,
+        , 2, Assem1,
+        , , , ,
+        "Adapter Status Connection";
+    ProxyConnect1 =
+        0x02010002, 0x44240305, , 0, , , , ,
+        "Proxied Digital Input";
+    ProxyConnect2 =
+        0x02010002, 0x44240305, , 0, , , , ,
+        "Proxied Digital Output";
+
+[Modular]
+    DefineSlotsInRack = 8;
+`
+
+func parseString(t *testing.T, src string) *eds {
+	t.Helper()
+	e, perr := parse(bytes.NewReader([]byte(src)))
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	return e
+}
+
+// isModularOf extracts src and returns the modular flag, failing on error.
+func isModularOf(t *testing.T, e *eds) bool {
+	t.Helper()
+	x, err := extract(logger.NewMockClient(), e)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return x.isModular
+}
+
+// A fixed-I/O EDS is not flagged modular.
+func TestExtractModular_FixedIO(t *testing.T) {
+	if isModularOf(t, parseSample(t)) {
+		t.Error("fixed-I/O sample should not be modular")
+	}
+}
+
+// A ProxyConnect entry flags the device modular.
+func TestExtractModular_ProxyConnect(t *testing.T) {
+	if !isModularOf(t, parseString(t, modularAdapterEDS)) {
+		t.Error("adapter with ProxyConnect entries should be modular")
+	}
+}
+
+// A [Modular] section alone (no ProxyConnect) flags the device modular.
+func TestExtractModular_SectionOnly(t *testing.T) {
+	if !isModularOf(t, parseString(t, "[Modular]\n    DefineSlotsInRack = 4;\n")) {
+		t.Error("a [Modular] section alone should be modular")
+	}
+}
+
+// End-to-end: a modular adapter still converts to a valid profile — its fixed
+// status assembly and identity survive; the dynamic proxied I/O is absent, with
+// warnings logged. It must not error or panic.
+func TestConvertModularAdapter(t *testing.T) {
+	profile, cerr := Convert(context.Background(), logger.NewMockClient(), []byte(modularAdapterEDS), nil)
+	if cerr != nil {
+		t.Fatalf("Convert modular adapter: %v", cerr)
+	}
+	var hasStatus bool
+	for _, r := range profile.DeviceResources {
+		if r.Name == "Adapter Status" {
+			hasStatus = true
+		}
+	}
+	if !hasStatus {
+		t.Error("expected the fixed 'Adapter Status' resource to survive")
+	}
+}

--- a/pkg/profileconv/eds/parser.go
+++ b/pkg/profileconv/eds/parser.go
@@ -1,0 +1,379 @@
+// Copyright (C) 2026 IOTech Ltd
+
+// This file is the EDS syntax layer: parse() reads EDS text into a generic,
+// semantics-free tree of sections/entries/fields. Fields are split on
+// out-of-quote commas with empty slots kept by position; each field is trimmed
+// of surrounding whitespace and its delimiting quotes, but its inner content
+// (including in-quote commas and escapes) is left verbatim.
+
+package eds
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+// EDS section names referenced across conversion stages. Defined once here so
+// the parser, extractor and mapper agree on the exact spelling (names are
+// matched case-sensitively as written in the EDS).
+const (
+	sectionDevice               = "Device"
+	sectionDeviceClassification = "Device Classification"
+	sectionParams               = "Params"
+	sectionAssembly             = "Assembly"
+	sectionConnectionManager    = "Connection Manager"
+	sectionFile                 = "File"
+	sectionModular              = "Modular"
+)
+
+// Size limits guarding against pathological input. A single physical line and a
+// single ";"-terminated statement (which may span many lines) are each capped;
+// the statement cap stops a file of short unterminated lines from being
+// concatenated without bound. maxErrMsgLen keeps a malformed fragment from
+// bloating an error message.
+const (
+	maxLineBytes      = 1024 * 1024
+	maxStatementBytes = 1024 * 1024
+	maxErrMsgLen      = 256
+)
+
+// eds is the parsed representation of one EDS file: an ordered list of sections.
+// Order is preserved so callers relying on declaration order (e.g. assembly
+// member layout) read fields as authored.
+type eds struct {
+	sections []*section
+}
+
+// section is a "[Name]" block containing zero or more entries.
+type section struct {
+	name    string
+	entries []*entry
+}
+
+// entry is a single "Keyword = field0, field1, ...;" statement.
+//
+// fields holds every comma-separated field, each trimmed of surrounding
+// whitespace and delimiting quotes, with empty slots kept as empty strings —
+// e.g. "0,,,0xC1" parses to ["0", "", "", "0xC1"] and "\"DO0\", 1" to
+// ["DO0", "1"]. Preserving empty slots is essential: EDS field meaning is
+// positional, so a dropped empty slot would shift every later field.
+type entry struct {
+	keyword string
+	fields  []string
+}
+
+// section returns the first section with the given name, or nil if absent.
+// Section names are matched case-sensitively as written in the EDS.
+func (e *eds) section(name string) *section {
+	for _, s := range e.sections {
+		if s.name == name {
+			return s
+		}
+	}
+	return nil
+}
+
+// sectionEntries returns the entries of every section with the given name,
+// concatenated in file order. An EDS occasionally repeats a section (e.g. two
+// [Params] blocks); reading only the first would silently drop the rest.
+func (e *eds) sectionEntries(name string) []*entry {
+	var entries []*entry
+	for _, s := range e.sections {
+		if s.name == name {
+			entries = append(entries, s.entries...)
+		}
+	}
+	return entries
+}
+
+// entry returns the first entry with the given keyword in the section, or nil.
+func (s *section) entry(keyword string) *entry {
+	for _, en := range s.entries {
+		if en.keyword == keyword {
+			return en
+		}
+	}
+	return nil
+}
+
+// field returns field i (0-indexed), already trimmed at parse time, or "" if i
+// is out of range. Out-of-range returns "" rather than panicking so callers can
+// read optional trailing fields without bounds checks.
+func (en *entry) field(i int) string {
+	if i < 0 || i >= len(en.fields) {
+		return ""
+	}
+	return en.fields[i]
+}
+
+// parse reads EDS text and returns its section/entry/field AST.
+//
+// It is purely syntactic — it understands the EDS grammar (sections, entries
+// terminated by ";", comma-separated fields, double-quoted strings with "\"
+// escapes, "$" comments) but attaches no CIP meaning. A statement spans multiple
+// lines simply by omitting ";" until it ends; there is no line-continuation
+// character. Unknown keywords and non-core sections are kept, not rejected, so
+// later stages decide what to use.
+//
+// A genuine read error on r is errors.KindServerError; malformed content — an
+// entry outside any section, a bad section header, an unterminated statement, or
+// a line exceeding the length cap — is errors.KindContractInvalid.
+func parse(r io.Reader) (*eds, errors.EdgeX) {
+	e := &eds{}
+	var cur *section        // section currently being filled; nil until first "[...]"
+	var buf strings.Builder // accumulates a statement across its physical lines
+
+	sc := bufio.NewScanner(r)
+	// EDS entries (e.g. large assemblies) can exceed bufio's default 64KB line
+	// cap once joined; raise the token limit to be safe.
+	sc.Buffer(make([]byte, 0, 64*1024), maxLineBytes)
+
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		if err := consumeLine(e, &cur, &buf, sc.Text(), lineNo); err != nil {
+			return nil, err
+		}
+	}
+	if err := sc.Err(); err != nil {
+		// A line exceeding the token cap is an input-size problem, not a server
+		// fault; classify it as a contract violation.
+		if err == bufio.ErrTooLong {
+			return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "EDS line exceeds the maximum supported length", err)
+		}
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to read EDS input", err)
+	}
+
+	// A statement left in the buffer at EOF was never terminated by ";".
+	// Rather than silently dropping it (which loses the file's last entry when
+	// the trailing ";" is missing or the file is truncated), report it.
+	if stmt := strings.TrimSpace(buf.String()); stmt != "" {
+		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unterminated statement at end of input (missing ';'): %s", truncateForErr(stmt)), nil)
+	}
+	return e, nil
+}
+
+// consumeLine processes one physical line: it rejects an unbalanced quote,
+// dispatches a section header, skips a blank line, or accumulates the line into
+// the current statement and flushes it on an unquoted ";".
+func consumeLine(e *eds, cur **section, buf *strings.Builder, raw string, lineNo int) errors.EdgeX {
+	line := stripComment(raw) // "$" comment runs to end of line
+
+	// A quoted string may not span lines (see scanLine), so an unbalanced quote
+	// is an error.
+	hasSemicolon, unbalanced := scanLine(line)
+	if unbalanced {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unterminated quoted string on line %d: %s", lineNo, strings.TrimSpace(line)), nil)
+	}
+
+	// Section headers stand alone on their own line, outside any pending statement.
+	trimmed := strings.TrimSpace(line)
+	handled, err := handleSectionHeader(e, cur, buf, trimmed)
+	if err != nil {
+		return err
+	}
+	if handled {
+		return nil
+	}
+	if buf.Len() == 0 && trimmed == "" {
+		return nil // blank line between statements
+	}
+
+	// Accumulate into the current statement. A statement ends at an unquoted ";",
+	// not at a newline, so one entry may span many lines. Cap the total so input
+	// of short unterminated lines cannot grow the buffer without bound.
+	buf.WriteString(line)
+	buf.WriteString(" ")
+	if buf.Len() > maxStatementBytes {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("EDS statement exceeds the maximum supported length near line %d", lineNo), nil)
+	}
+	if !hasSemicolon {
+		return nil
+	}
+
+	stmt := strings.TrimSpace(buf.String())
+	buf.Reset()
+	return addStatement(cur, stmt)
+}
+
+// handleSectionHeader consumes trimmed if it is a "[...]" section header,
+// appending the new section and pointing cur at it. It reports handled=false for
+// a non-header line. A header arriving while a statement is still buffered, a
+// missing "]", or trailing content after "]" is a contract error.
+func handleSectionHeader(e *eds, cur **section, buf *strings.Builder, trimmed string) (handled bool, err errors.EdgeX) {
+	if !strings.HasPrefix(trimmed, "[") {
+		return false, nil
+	}
+	// A header while a statement is buffered means the previous statement was
+	// never terminated by ";".
+	if buf.Len() > 0 && strings.Contains(trimmed, "]") {
+		return false, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("section header while previous statement is unterminated (missing ';'): %s", truncateForErr(buf.String())), nil)
+	}
+	if buf.Len() > 0 {
+		return false, nil // "[" mid-statement, not a header
+	}
+	end := strings.Index(trimmed, "]")
+	if end < 0 {
+		return false, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("malformed section header (missing ']'): %s", trimmed), nil)
+	}
+	// Reject content after "]"; it would be silently dropped otherwise.
+	if strings.TrimSpace(trimmed[end+1:]) != "" {
+		return false, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unexpected content after section header ']': %s", trimmed), nil)
+	}
+	sec := &section{name: strings.TrimSpace(trimmed[1:end])}
+	e.sections = append(e.sections, sec)
+	*cur = sec
+	return true, nil
+}
+
+// truncateForErr trims s to maxErrMsgLen so a malformed fragment cannot bloat an
+// error message; it also collapses leading/trailing space.
+func truncateForErr(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > maxErrMsgLen {
+		return s[:maxErrMsgLen] + "…"
+	}
+	return s
+}
+
+// addStatement parses one complete statement and appends it to the current
+// section. Empty statements are ignored; a statement with no "=" is a tolerated
+// stray token. Shared by the main loop and EOF handling so both paths treat a
+// completed statement identically.
+func addStatement(cur **section, stmt string) errors.EdgeX {
+	if stmt == "" {
+		return nil
+	}
+	en, err := parseEntry(stmt)
+	if err != nil {
+		return err
+	}
+	if en == nil {
+		return nil // no "=" and not a section — tolerate stray tokens
+	}
+	if *cur == nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("entry outside any section: %s", stmt), nil)
+	}
+	(*cur).entries = append((*cur).entries, en)
+	return nil
+}
+
+// scanLine scans one line and reports whether it holds an unquoted ";" (a
+// statement terminator) and whether its quotes are left open (unbalanced).
+// Because the CIP grammar forbids a string from spanning lines, quote state is
+// not carried across lines — so a caller can treat unbalanced as an error and
+// each line is scanned independently.
+func scanLine(line string) (hasSemicolon, unbalanced bool) {
+	inQuote := false
+	backslashes := 0
+	for _, r := range line {
+		switch {
+		case isUnescapedQuote(r, backslashes):
+			inQuote = !inQuote // flip: entering or leaving a quoted string
+		case r == ';' && !inQuote:
+			hasSemicolon = true
+		}
+		backslashes = runBackslashes(backslashes, r)
+	}
+	return hasSemicolon, inQuote
+}
+
+// isUnescapedQuote reports whether r is a double quote that acts as a string
+// delimiter — i.e. not escaped by an odd-length run of preceding backslashes.
+// backslashes is the count of "\" immediately before r, so a "\\" pair (an
+// escaped backslash) leaves the following quote unescaped. Callers use it to
+// toggle quote state while scanning.
+//
+//	isUnescapedQuote('"', 0) // true  (no backslash)
+//	isUnescapedQuote('"', 1) // false (\" — escaped)
+//	isUnescapedQuote('"', 2) // true  (\\" — escaped backslash, then a delimiter)
+func isUnescapedQuote(r rune, backslashes int) bool {
+	return r == '"' && backslashes%2 == 0
+}
+
+// runBackslashes updates the count of consecutive "\" ending at r: it grows on a
+// backslash and resets on anything else, so callers can tell whether the next
+// quote is escaped (odd run) or a delimiter (even run).
+func runBackslashes(count int, r rune) int {
+	if r == '\\' {
+		return count + 1
+	}
+	return 0
+}
+
+// parseEntry splits one statement "Keyword = f0, f1, ...;" into its keyword and
+// verbatim fields. Returns (nil, nil) if the statement has no "=" (a stray token
+// the parser tolerates rather than rejects).
+func parseEntry(stmt string) (*entry, errors.EdgeX) {
+	stmt = strings.TrimRight(stmt, "; \t") // trailing ";" terminates an entry
+
+	eq := strings.Index(stmt, "=")
+	if eq < 0 {
+		return nil, nil
+	}
+	keyword := strings.TrimSpace(stmt[:eq])
+	if keyword == "" {
+		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("entry with empty keyword: %s", stmt), nil)
+	}
+
+	return &entry{keyword: keyword, fields: splitFields(stmt[eq+1:])}, nil
+}
+
+// splitFields splits a field list on commas that fall outside quotes, trimming
+// each field but preserving empty slots. "0,,,0xC1" -> ["0","","","0xC1"];
+// "\"a, b\", c" -> ["a, b", "c"] (a comma inside quotes is part of the field).
+func splitFields(s string) []string {
+	var fields []string
+	var field strings.Builder
+	inQuote := false
+	backslashes := 0
+
+	// appendField finalizes the accumulated field: trim surrounding whitespace,
+	// then strip ONE pair of delimiting quotes (not every quote), so a field whose
+	// content ends in an escaped quote — e.g. "a\"" -> a\" — keeps that quote.
+	appendField := func() {
+		text := strings.TrimSpace(field.String())
+		if len(text) >= 2 && text[0] == '"' && text[len(text)-1] == '"' {
+			text = text[1 : len(text)-1]
+		}
+		fields = append(fields, text)
+		field.Reset()
+	}
+
+	for _, r := range s {
+		switch {
+		case isUnescapedQuote(r, backslashes):
+			inQuote = !inQuote
+			field.WriteRune(r)
+		case r == ',' && !inQuote: // separator: end the current field
+			appendField()
+		default:
+			field.WriteRune(r)
+		}
+		backslashes = runBackslashes(backslashes, r)
+	}
+	appendField() // the text after the last comma is the final field
+	return fields
+}
+
+// stripComment removes a "$" comment (to end of line), ignoring "$" inside a
+// quoted string. A '"' preceded by '\' is an escaped quote and does not open or
+// close a string. EDS uses "$" as its line-comment marker.
+func stripComment(line string) string {
+	inQuote := false
+	backslashes := 0
+	for i, r := range line {
+		switch {
+		case isUnescapedQuote(r, backslashes):
+			inQuote = !inQuote
+		case r == '$' && !inQuote:
+			return line[:i]
+		}
+		backslashes = runBackslashes(backslashes, r)
+	}
+	return line
+}

--- a/pkg/profileconv/eds/parser_test.go
+++ b/pkg/profileconv/eds/parser_test.go
@@ -1,0 +1,467 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package eds
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+func TestSplitFields(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		// The critical case: empty slots must be preserved by position.
+		{"empty slots preserved", "0,,,0xC1", []string{"0", "", "", "0xC1"}},
+		{"single field", "42", []string{"42"}},
+		{"trailing empty", "1,2,", []string{"1", "2", ""}},
+		{"leading empty", ",1,2", []string{"", "1", "2"}},
+		{"whitespace trimmed", " 1 , 2 ", []string{"1", "2"}},
+		{"quotes stripped", `"DO0","DO1"`, []string{"DO0", "DO1"}},
+		{"comma inside quotes kept", `"a, b", c`, []string{"a, b", "c"}},
+		{"hex preserved verbatim", "0x0000,0xC1", []string{"0x0000", "0xC1"}},
+		// Escaped quote (odd backslash run): the \" stays inside the field, so
+		// the following comma is not a separator.
+		{"escaped quote keeps comma inside", `"a \" b, c", d`, []string{`a \" b, c`, "d"}},
+		// Escaped backslash then a real delimiter (even run): \\" closes the
+		// string, so the next comma DOES separate.
+		{"escaped backslash closes quote", `"a\\", b`, []string{`a\\`, "b"}},
+		// Only ONE pair of delimiter quotes is stripped, so content ending in an
+		// escaped quote keeps it (a greedy Trim would eat that quote too).
+		{"content ending in escaped quote", `"a\""`, []string{`a\"`}},
+		{"content is only an escaped quote", `"\""`, []string{`\"`}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitFields(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("field count: got %d %q, want %d %q", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("field %d: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestStripComment(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"VendCode = 1;  $ a comment", "VendCode = 1;  "},
+		{`Name = "a$b";  $ dollar in quotes kept`, `Name = "a$b";  `},
+		{"$ whole line comment", ""},
+		{"no comment here", "no comment here"},
+	}
+	for _, tt := range tests {
+		if got := stripComment(tt.in); got != tt.want {
+			t.Errorf("stripComment(%q): got %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParseBasicSections(t *testing.T) {
+	src := `
+[Device]
+    VendName = "Demo Corp";   $ manufacturer
+    ProdName = "DEMO-DIO8";
+
+[Params]
+    Param1 = 0,,,0x0000,0xC1,1,"DO0";
+`
+	e, err := parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	dev := e.section(sectionDevice)
+	if dev == nil {
+		t.Fatal("missing [Device] section")
+	}
+	if got := dev.entry("VendName").field(0); got != "Demo Corp" {
+		t.Errorf("VendName: got %q, want %q", got, "Demo Corp")
+	}
+
+	// Positional field access on the dense [Params] line: field 4 is the CIP
+	// data type (0xC1), which only survives if empty slots 1 and 2 are kept.
+	p1 := e.section(sectionParams).entry("Param1")
+	if got := p1.field(4); got != "0xC1" {
+		t.Errorf("Param1 field 4 (data type): got %q, want %q", got, "0xC1")
+	}
+	if got := p1.field(6); got != "DO0" {
+		t.Errorf("Param1 field 6 (name): got %q, want %q", got, "DO0")
+	}
+}
+
+// A statement spans multiple physical lines with no continuation character;
+// only the ";" ends it. (EDS has no line-continuation marker.)
+func TestParseMultiLineStatement(t *testing.T) {
+	src := `
+[Assembly]
+    Assem100 = "Outputs",
+        "20 04 24 64 30 03",
+        1, Param1;
+`
+	e, err := parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	a := e.section(sectionAssembly).entry("Assem100")
+	if a == nil {
+		t.Fatal("missing Assem100")
+	}
+	// The three lines must join into one entry.
+	if got, want := len(a.fields), 4; got != want {
+		t.Fatalf("Assem100 fields: got %d %q, want %d", got, a.fields, want)
+	}
+	if a.field(0) != "Outputs" || a.field(3) != "Param1" {
+		t.Errorf("Assem100 fields not joined correctly: %q", a.fields)
+	}
+}
+
+// assertDeviceAFields parses one EDS source, then checks that entry "A" of the
+// [Device] section split into exactly want.
+func assertDeviceAFields(t *testing.T, src string, want []string) {
+	t.Helper()
+	e, err := parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	a := e.section(sectionDevice).entry("A")
+	if a == nil {
+		t.Fatal("entry A missing")
+	}
+	if len(a.fields) != len(want) {
+		t.Fatalf("fields: got %d %q, want %d %q", len(a.fields), a.fields, len(want), want)
+	}
+	for i := range want {
+		if a.field(i) != want[i] {
+			t.Errorf("field %d: got %q, want %q", i, a.field(i), want[i])
+		}
+	}
+}
+
+// A '\"' inside a quoted field is an escaped quote, not a string boundary: it
+// must not flip quote state, so a "," after it stays inside the field and the
+// real closing quote still ends the field correctly.
+func TestParseEscapedQuoteInString(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields string // the field list after "A = "
+		want   []string
+	}{
+		// One escaped quote, then an in-quote comma.
+		{"single escape", `"a \" b, c", d`, []string{`a \" b, c`, "d"}},
+		// A pair of escaped quotes around text, plus an in-quote comma; the
+		// paired \" must not open/close the string, so it stays one field.
+		{"paired escapes", `"he said \"hi\", ok", 42`, []string{`he said \"hi\", ok`, "42"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertDeviceAFields(t, "[Device]\n    A = "+tt.fields+";\n", tt.want)
+		})
+	}
+}
+
+// Per the CIP grammar a quoted string may not span physical lines; an unbalanced
+// quote on a line is a contract error.
+func TestParseUnterminatedStringErrors(t *testing.T) {
+	_, err := parse(strings.NewReader("[Device]\n    A = \"open;\n"))
+	if err == nil {
+		t.Fatal("expected error for unterminated quoted string")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("error kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+	}
+}
+
+func TestParseEntryOutsideSectionErrors(t *testing.T) {
+	_, err := parse(strings.NewReader("Orphan = 1;\n"))
+	if err == nil {
+		t.Fatal("expected error for entry outside any section")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("error kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+	}
+}
+
+// Regression: a ";" inside a quoted field must not terminate the statement.
+// A whole-line Contains check would end the statement at the quoted ";" and
+// drop the fields on the following lines.
+func TestParseSemicolonInsideQuotesNotTerminator(t *testing.T) {
+	src := `
+[Device]
+    A = "desc; more",
+        42,
+        99;
+`
+	assertDeviceAFields(t, src, []string{"desc; more", "42", "99"})
+}
+
+// Regression: a statement not terminated by ";" before EOF must be
+// reported, not silently dropped.
+func TestParseUnterminatedStatementAtEOFErrors(t *testing.T) {
+	_, err := parse(strings.NewReader("[Device]\n    Name = \"x\"\n"))
+	if err == nil {
+		t.Fatal("expected error for unterminated statement at EOF")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("error kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+	}
+}
+
+// parseSample parses the coverage EDS from testdata, failing the test on error.
+// ethernetip-sample.eds is the single golden fixture; it is hand-authored to
+// fire every parser path, so a per-case reader literal is unnecessary.
+func parseSample(t *testing.T) *eds {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "ethernetip-sample.eds"))
+	if err != nil {
+		t.Fatalf("read sample: %v", err)
+	}
+	e, edgexErr := parse(strings.NewReader(string(data)))
+	if edgexErr != nil {
+		t.Fatalf("parse: %v", edgexErr)
+	}
+	return e
+}
+
+// The parser must ingest the full sample without erroring and expose its
+// sections.
+func TestParseSampleSections(t *testing.T) {
+	e := parseSample(t)
+	if len(e.sections) == 0 {
+		t.Fatal("no sections parsed")
+	}
+	for _, want := range []string{sectionDevice, sectionParams, sectionAssembly, sectionConnectionManager} {
+		if e.section(want) == nil {
+			t.Errorf("expected section %q not found", want)
+		}
+	}
+}
+
+// ethernetip-sample.eds exercises the syntax edge cases (coverage marker [K]):
+// unknown keywords, non-core sections and multi-value comma lists must all parse
+// cleanly and preserve the golden [Assembly] field layout.
+func TestParseCoverageEdgeCases(t *testing.T) {
+	e := parseSample(t)
+
+	// Unknown keyword is kept, not dropped. Vendor_Custom_Flag sits in the
+	// [Device Classification] section in the sample.
+	if e.section(sectionDeviceClassification).entry("Vendor_Custom_Flag") == nil {
+		t.Error("unknown keyword Vendor_Custom_Flag was dropped")
+	}
+	// Non-core section is kept.
+	if e.section("Ethernet Link Class") == nil {
+		t.Error("non-core section [Ethernet Link Class] was dropped")
+	}
+	// Golden [Assembly] layout: Assem100 field 0 is the name, and the dense
+	// member list survives field splitting.
+	assem := e.section(sectionAssembly).entry("Assem100")
+	if assem == nil {
+		t.Fatal("missing Assem100")
+	}
+	if got := assem.field(0); got != "Output Assembly" {
+		t.Errorf("Assem100 field 0: got %q, want %q", got, "Output Assembly")
+	}
+}
+
+// Param5's description quotes a comma; it must stay one field, not split. Param6
+// spans several lines with no continuation char; its fields must join into one
+// entry. Both are embedded in the sample so the single fixture covers these paths.
+func TestParseSampleMultiLineAndQuotedComma(t *testing.T) {
+	params := parseSample(t).section(sectionParams)
+
+	// Quoted comma: Param5 field 8 is the description "signed, 8-bit output".
+	// If the comma split the field, field 8 would be "signed" and the type/
+	// name/range fields after it would all shift.
+	p5 := params.entry("Param5")
+	if got := p5.field(8); got != "signed, 8-bit output" {
+		t.Errorf("Param5 description (quoted comma): got %q, want %q", got, "signed, 8-bit output")
+	}
+	if got := p5.field(4); got != "0xC2" {
+		t.Errorf("Param5 field 4 (data type) shifted by quoted comma: got %q, want %q", got, "0xC2")
+	}
+
+	// Multi-line: Param6's lines join, so field 4 (the CIP type) is still 0xC3.
+	p6 := params.entry("Param6")
+	if got := p6.field(4); got != "0xC3" {
+		t.Errorf("Param6 field 4 after multi-line join: got %q, want %q", got, "0xC3")
+	}
+}
+
+// --- Edge cases and error paths ---
+
+func TestParseEmptyInput(t *testing.T) {
+	e, err := parse(strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("empty input should parse cleanly: %v", err)
+	}
+	if len(e.sections) != 0 {
+		t.Errorf("empty input: got %d sections, want 0", len(e.sections))
+	}
+}
+
+func TestParseCommentsOnly(t *testing.T) {
+	e, err := parse(strings.NewReader("$ a comment\n$ another\n"))
+	if err != nil {
+		t.Fatalf("comment-only input should parse cleanly: %v", err)
+	}
+	if len(e.sections) != 0 {
+		t.Errorf("comment-only input: got %d sections, want 0", len(e.sections))
+	}
+}
+
+func TestParseCRLFLineEndings(t *testing.T) {
+	e, err := parse(strings.NewReader("[Device]\r\n    Name = \"x\";\r\n"))
+	if err != nil {
+		t.Fatalf("CRLF input: %v", err)
+	}
+	// The trailing "\r" must not leak into the section name or field value.
+	if e.section(sectionDevice) == nil {
+		t.Fatal("Device section not found (CRLF leaked into name?)")
+	}
+	if got := e.section(sectionDevice).entry("Name").field(0); got != "x" {
+		t.Errorf("field with CRLF: got %q, want %q", got, "x")
+	}
+}
+
+func TestParseMalformedHeaderMissingBracket(t *testing.T) {
+	_, err := parse(strings.NewReader("[Device\n"))
+	if err == nil {
+		t.Fatal("expected error for header missing ']'")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("error kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+	}
+}
+
+func TestParseEmptyKeywordErrors(t *testing.T) {
+	_, err := parse(strings.NewReader("[Device]\n    = 1;\n"))
+	if err == nil {
+		t.Fatal("expected error for empty keyword")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("error kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+	}
+}
+
+// Content after the closing "]" must not be silently dropped.
+func TestParseContentAfterHeaderErrors(t *testing.T) {
+	_, err := parse(strings.NewReader("[Device] VendCode = 1;\n"))
+	if err == nil {
+		t.Fatal("expected error for content after ']'")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("error kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+	}
+}
+
+// A new section header while the previous statement is unterminated must be
+// reported, not swallowed into the pending statement.
+func TestParseHeaderWhileUnterminatedErrors(t *testing.T) {
+	_, err := parse(strings.NewReader("[A]\n    Name = 1\n[B]\n    Other = 2;\n"))
+	if err == nil {
+		t.Fatal("expected error for header during unterminated statement")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("error kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+	}
+}
+
+// A physical line longer than the scanner cap is an input problem, reported
+// as KindContractInvalid rather than a server fault.
+func TestParseOverlongLineErrors(t *testing.T) {
+	huge := "[Device]\n    Name = \"" + strings.Repeat("a", 2*1024*1024) + "\";\n"
+	_, err := parse(strings.NewReader(huge))
+	if err == nil {
+		t.Fatal("expected error for overlong line")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("error kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+	}
+}
+
+// A statement built from many short unterminated lines (no ";") must hit the
+// accumulated-statement cap, not grow the buffer without bound. Each line is
+// well under the per-line cap, so only the statement cap can stop it.
+func TestParseOverlongStatementErrors(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("[Device]\n    Name =\n")
+	for b.Len() < 2*maxStatementBytes {
+		b.WriteString("aaaaaaaa\n") // short line, never a ";"
+	}
+	_, err := parse(strings.NewReader(b.String()))
+	if err == nil {
+		t.Fatal("expected error for overlong statement")
+	}
+	if errors.Kind(err) != errors.KindContractInvalid {
+		t.Errorf("error kind: got %v, want %v", errors.Kind(err), errors.KindContractInvalid)
+	}
+}
+
+// errReader always fails, to exercise the genuine read-error path.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+
+func TestParseReadErrorIsServerError(t *testing.T) {
+	_, err := parse(errReader{})
+	if err == nil {
+		t.Fatal("expected error from failing reader")
+	}
+	if errors.Kind(err) != errors.KindServerError {
+		t.Errorf("error kind: got %v, want %v", errors.Kind(err), errors.KindServerError)
+	}
+}
+
+// A token with no "=" inside a section is tolerated (skipped), not an error.
+func TestParseBareTokenTolerated(t *testing.T) {
+	e, err := parse(strings.NewReader("[Device]\n    JustAToken;\n    Name = \"x\";\n"))
+	if err != nil {
+		t.Fatalf("bare token should be tolerated: %v", err)
+	}
+	dev := e.section(sectionDevice)
+	if dev.entry("Name") == nil {
+		t.Error("Name entry lost after bare token")
+	}
+	if got := len(dev.entries); got != 1 {
+		t.Errorf("entries: got %d, want 1 (bare token should not create an entry)", got)
+	}
+}
+
+// parseEntry splits on the first "=" only; a value containing "=" is kept.
+func TestParseMultipleEqualsSplitsOnFirst(t *testing.T) {
+	e, err := parse(strings.NewReader("[Device]\n    A = a=b, c;\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	a := e.section(sectionDevice).entry("A")
+	if a == nil {
+		t.Fatal("entry A missing")
+	}
+	want := []string{"a=b", "c"}
+	if len(a.fields) != len(want) || a.field(0) != want[0] || a.field(1) != want[1] {
+		t.Errorf("fields: got %q, want %q", a.fields, want)
+	}
+}
+
+func TestEntryFieldOutOfRange(t *testing.T) {
+	en := &entry{keyword: "A", fields: []string{"x"}}
+	if got := en.field(-1); got != "" {
+		t.Errorf("field(-1): got %q, want empty", got)
+	}
+	if got := en.field(5); got != "" {
+		t.Errorf("field(5): got %q, want empty", got)
+	}
+	if got := en.field(0); got != "x" {
+		t.Errorf("field(0): got %q, want %q", got, "x")
+	}
+}

--- a/pkg/profileconv/eds/testdata/ethernetip-sample.eds
+++ b/pkg/profileconv/eds/testdata/ethernetip-sample.eds
@@ -1,0 +1,326 @@
+$ =============================================================================
+$  COVERAGE synthetic EDS - designed to MAXIMIZE converter test coverage
+$  (NOT a real device)
+$ =============================================================================
+$
+$  WARNING: fully hand-written/synthetic. All identity values are placeholders.
+$  Purpose: make every EDS -> XRT profile converter path fire from a single
+$  file, so it can serve as a golden unit-test baseline.
+$
+$  Intentional coverage:
+$    [A] Every CIP data type code (S2.7): C1..CB, D0..D4, DA  -> see [Params]
+$    [B] Bidirectional I/O + both readWrite directions (S4.4):
+$          O2T-only = W (DO0..2, SINT, INT, DINT, REAL, Mode)
+$          T2O-only = R (LINT, ULINT, LREAL, USINT, WORD, DWORD)
+$          both O2T+T2O (Setpoint / Param24, in Assem100 AND Assem101) -> TWO
+$          resources: an O2T one (W) and a T2O one (R), not a single RW resource
+$    [C] Assembly member offset accumulation (S4.3): BOOL bit packing, pad
+$          alignment, natural byte alignment, multi-byte types, byte crossing
+$          -- offsets are validated (see appendix at end of file)
+$    [D] Two member-size styles: explicit bit count vs empty (use Param Data Size)
+$    [E] pad/reserved param: occupies offset but produces NO resource (S4.2, S2.8)
+$    [F] Enum sub-entry (S2.4.1) -> a DeviceCommand whose resourceOperation
+$        carries value->label mappings (Param9/Enum9 -> "Output Mode" command)
+$    [G] Scaling (mult/div/base/offset, S2.4) -> properties.scale/base/offset
+$    [H] min/max/default (typed per DATATYPE_REF, S2.4)
+$    [I] Config assembly (S3.1 (1)) -> ConfigSettings resource
+$    [J] Explicit messaging via [Params] Link Path (S4.5) -> objClass/instID/attrID
+$    [K] Unknown keyword / non-core sections: parser must ignore, not error
+$    [L] valueType casing normalization unaffected (type comes from code, not text)
+$ =============================================================================
+
+[File]
+    DescText   = "COVERAGE synthetic EDS - exercises every converter path";
+    CreateDate = 07-22-2026;
+    CreateTime = 00:00:00;
+    ModDate    = 07-22-2026;
+    ModTime    = 00:00:00;
+    Revision   = 1.0;
+    HomeURL    = "https://example.invalid/coverage.eds";   $ [K] non-core field
+
+[Device]
+    VendCode    = 9999;                 $ placeholder
+    VendName    = "Coverage Test Vendor";
+    ProdType    = 7;                    $ 7 = General Purpose Discrete I/O
+    ProdTypeStr = "Coverage Test Device";
+    ProdCode    = 4242;
+    MajRev      = 3;
+    MinRev      = 14;
+    ProdName    = "EtherNetIP Sample";  $ -> profile.model / name (needs sanitizing)
+    Catalog     = "EtherNetIP Sample";
+    Icon        = "coverage.ico";
+
+[Device Classification]
+    Class1 = EtherNetIP;
+
+$ [K] unknown / vendor-specific keyword -- parser must ignore, not error
+    Vendor_Custom_Flag = 0xABCD1234;
+
+$ *********************************************************************************
+$ [Params] -- covers every CIP type + enum + scaling + Link Path explicit
+$ *********************************************************************************
+[Params]
+
+$ ---- [B] O2T (Output, writable W) members ----
+    $ [A] BOOL 0xC1
+    Param1 = 0,,,0x0000,0xC1,1,"DO Channel 0","","Digital output 0";
+    Param2 = 0,,,0x0000,0xC1,1,"DO Channel 1","","Digital output 1";
+    Param3 = 0,,,0x0000,0xC1,1,"DO Channel 2","","Digital output 2";
+
+    $ [E] pad: 5 bits to fill byte0 -- name marked RESERVED, produces NO resource
+    Param4 = 0,,,0x0000,0xC1,1,"RESERVED_pad5","","pad - not a resource";
+
+    $ [A] SINT 0xC2 (8-bit signed) -- description quotes a comma to exercise
+    $     the "comma inside quotes is not a field separator" parser rule
+    Param5 = 0,,,0x0000,0xC2,1,"Output SINT","counts","signed, 8-bit output",-128,127,0;
+
+    $ [A] INT 0xC3 (16-bit signed) + [G] scaling (mult=1 div=10 -> scale 0.1) + [H] min/max/default
+    $     spans several lines with no continuation char — the ";" alone ends it
+    Param6 =
+        0,,,0x0000,
+        0xC3,2,
+        "Output INT scaled","deg","16-bit signed with scaling",
+        -3200,3200,0,               $ [H] min,max,default
+        1,10,0,0,                   $ [G] mult,div,base,offset -> scale=0.1
+        ,,,,
+        ;
+
+    $ [A] DINT 0xC4 (32-bit signed)
+    Param7 = 0,,,0x0000,0xC4,4,"Output DINT","steps","32-bit signed",-2000000,2000000,0;
+
+    $ [A] REAL 0xCA (32-bit float)
+    Param8 = 0,,,0x0000,0xCA,4,"Output REAL","V","32-bit float";
+
+    $ [A] UINT 0xC7 (16-bit unsigned) + [F] enum
+    Param9 =
+        0,,,0x0010,                 $ Descriptor bit4=1 -> supports enumeration
+        0xC7,2,
+        "Output Mode","","enumerated mode select",
+        0,3,0;
+    Enum9 =
+        0,"Idle",
+        1,"Run",
+        2,"Jog",
+        3,"Home";
+
+$ ---- [B] T2O (Input, read-only R) members ----
+    $ [A] LINT 0xC5 (64-bit signed)
+    Param10 = 0,,,0x0000,0xC5,8,"Input LINT","","64-bit signed input";
+    $ [A] ULINT 0xC9 (64-bit unsigned)
+    Param11 = 0,,,0x0000,0xC9,8,"Input ULINT","","64-bit unsigned input";
+    $ [A] LREAL 0xCB (64-bit float)
+    Param12 = 0,,,0x0000,0xCB,8,"Input LREAL","","64-bit float input";
+    $ [A] USINT 0xC6 (8-bit unsigned)
+    Param13 = 0,,,0x0000,0xC6,1,"Input USINT","","8-bit unsigned input",0,255,0;
+    $ [E] pad 8-bit (for byte alignment) -- produces NO resource
+    Param14 = 0,,,0x0000,0xC6,1,"RESERVED_pad8","","pad - not a resource";
+    $ [A] WORD 0xD2 (16-bit bit string)
+    Param15 = 0,,,0x0000,0xD2,2,"Input WORD","","16-bit bit string";
+    $ [A] DWORD 0xD3 (32-bit bit string)
+    Param16 = 0,,,0x0000,0xD3,4,"Input DWORD","","32-bit bit string";
+
+$ ---- [I] Config assembly members ----
+    $ [A] UDINT 0xC8 (32-bit unsigned) -- also referenced by [Connection Manager] RPI
+    Param17 = 0,,,0x0000,0xC8,4,"RPI","us","Requested Packet Interval",1000,3200000,10000;
+    $ [A] BYTE 0xD1 (8-bit bit string)
+    Param18 = 0,,,0x0000,0xD1,1,"Config Flags","","8-bit config bitfield";
+    $ [A] LWORD 0xD4 (64-bit bit string)
+    Param19 = 0,,,0x0000,0xD4,8,"Config Mask","","64-bit bit string";
+
+$ ---- [A] String types (cover D0 / DA) as explicit-messaging resources ----
+$   Both carry a Link Path so they become explicit resources (S4.5) and the
+$   D0/DA conversion paths actually run (a Param with no assembly ref and no
+$   Link Path would produce NO resource -- see Param selection rule S4.2).
+    $ STRING 0xD0 -- Link Path 20 01 24 01 30 07 -> Identity/1/7 (ProductName)
+    Param20 =
+        0,
+        6,                          $ [1] Link Path Size = 6 bytes
+        "20 01 24 01 30 07",        $ [2] Link Path -> Identity/1/7
+        0x0000,
+        0xD0,32,                    $ STRING
+        "Device Tag","","STRING attribute via explicit";
+    $ SHORT_STRING 0xDA -- Link Path 20 67 24 01 30 01 -> class 0x67/1/1 (vendor obj)
+    Param21 =
+        0,
+        6,                          $ [1] Link Path Size = 6 bytes
+        "20 67 24 01 30 01",        $ [2] Link Path -> objClass=0x67, instID=1, attrID=1
+        0x0000,
+        0xDA,16,                    $ SHORT_STRING
+        "Short Label","","SHORT_STRING attribute via explicit";
+
+$ ---- [B] Shared point: referenced by BOTH O2T (Assem100) and T2O (Assem101) ----
+$   Same param in an output AND an input assembly -> TWO resources: O2T (W) and
+$   T2O (R), direction-suffixed on the name collision (S4.4).
+    $ INT 0xC3 -- setpoint written via O2T, read back via T2O
+    Param24 = 0,,,0x0000,0xC3,2,"Setpoint","deg","RW: written O2T, read back T2O",-3200,3200,0;
+
+$ ---- [J] Explicit messaging: Params with a Link Path (S4.5) ----
+    $ Link Path = 20 01 24 01 30 07 -> objClass=1 (Identity), instID=1, attrID=7 (ProductName)
+    $ field[1]=Link Path Size (bytes), field[2]=Link Path (EPATH)
+    Param22 =
+        0,
+        6,                          $ [1] Link Path Size = 6 bytes
+        "20 01 24 01 30 07",        $ [2] Link Path -> Identity/1/7
+        0x0000,
+        0xD0,32,                    $ STRING
+        "ProductName (explicit)","","Identity object Product Name via explicit";
+
+    $ Link Path = 20 01 24 01 30 06 -> objClass=1, instID=1, attrID=6 (SerialNumber)
+    Param23 =
+        0,
+        6,
+        "20 01 24 01 30 06",
+        0x0000,
+        0xC8,4,                     $ UDINT
+        "SerialNumber (explicit)","","Identity object Serial Number via explicit";
+
+$ *********************************************************************************
+$ [Assembly] -- [C] offset accumulation + [D] two size styles + [E] pad
+$   Offsets validated by script; see appendix at end of file.
+$ *********************************************************************************
+[Assembly]
+    Object_Name       = "Assembly Object";
+    Object_Class_Code = 0x04;
+    Revision          = 2;
+
+    $ --- O2T Output Assembly (instance 0x64=100, size 16 bytes) ---
+    $ [D] EXPLICIT bit counts here (shows explicit member size + BOOL packing + pad)
+    Assem100 =
+        "Output Assembly",
+        "20 04 24 64 30 03",        $ Path -> Class4, Instance 0x64=100, Attr3
+        16,                         $ Size = 16 bytes (validated)
+        0x0001,                     $ Descriptor - editable
+        , ,
+        1,  Param1,                 $ DO0     bit0    (byte0.0)
+        1,  Param2,                 $ DO1     bit1    (byte0.1)
+        1,  Param3,                 $ DO2     bit2    (byte0.2)
+        5,  Param4,                 $ [E] pad bit3-7  (byte0.3) no resource
+        8,  Param5,                 $ SINT    byte1
+        16, Param6,                 $ INT     byte2-3 (scaled)
+        32, Param7,                 $ DINT    byte4-7
+        32, Param8,                 $ REAL    byte8-11
+        16, Param9,                 $ UINT    byte12-13 (enum)
+        16, Param24;                $ INT     byte14-15 (O2T W side; also in Assem101)
+
+    $ --- T2O Input Assembly (instance 0x65=101, size 34 bytes) ---
+    $ [D] EMPTY member size here (shows the "use Param Data Size" fallback path)
+    Assem101 =
+        "Input Assembly",
+        "20 04 24 65 30 03",        $ Path -> Instance 0x65=101
+        34,                         $ Size = 34 bytes (validated)
+        0x0000,                     $ Descriptor - read only
+        , ,
+        , Param10,                  $ LINT   byte0-7    (empty size -> 8 bytes)
+        , Param11,                  $ ULINT  byte8-15
+        , Param12,                  $ LREAL  byte16-23
+        , Param13,                  $ USINT  byte24
+        , Param14,                  $ [E] pad byte25    no resource
+        , Param15,                  $ WORD   byte26-27
+        , Param16,                  $ DWORD  byte28-31
+        , Param24;                  $ INT    byte32-33  (T2O R side; also in Assem100)
+
+    $ --- [I] Config Assembly (instance 0x6E=110) ---
+    Assem110 =
+        "Config Assembly",
+        "20 04 24 6E 30 03",        $ Path -> Instance 0x6E=110
+        13,                         $ Size = 4+1+8 = 13 bytes
+        0x0001,                     $ editable
+        , ,
+        32, Param17,                $ RPI (UDINT)   byte0-3
+        8,  Param18,                $ Config Flags  byte4
+        64, Param19;                $ Config Mask   byte5-12
+
+$ *********************************************************************************
+$ [Connection Manager] -- [B] direction inference source
+$   Connection1: O2T->Assem100 (W), T2O->Assem101 (R), config->Assem110
+$ *********************************************************************************
+[Connection Manager]
+    Object_Name       = "Connection Manager Object";
+    Object_Class_Code = 0x06;
+
+    Connection1 =
+        0x04010002,                 $ [0] trigger & transport (Class1, cyclic, exclusive-owner)
+        0x44640405,                 $ [1] params: O2T fixed + 32-bit run/idle header
+                                    $      -> O2TSettings.includeHeader32bit = true (S2.6.1)
+        Param17, 16, Assem100,      $ [2][3][4] O2T RPI/Size/Format -> Assem100 (writable W)
+        Param17, 34, Assem101,      $ [5][6][7] T2O RPI/Size/Format -> Assem101 (read-only R)
+        , ,                         $ [8][9] Proxy config
+        , Assem110,                 $ [10][11] Target config -> Assem110 (ConfigSettings)
+        "Coverage IO Connection",   $ [12] name
+        "Exercises O2T/T2O/config in one connection",  $ [13] help
+        "20 04 24 6E 2C 64 2C 65";  $ [14] connection path
+
+$ *********************************************************************************
+$ [Capacity] / [Ethernet Link Class] -- [K] non-core sections, parser should ignore
+$ *********************************************************************************
+[Capacity]
+    MaxCIPConnections = 4;
+    TSpec1 = TxRx, 32, 1000;
+
+[Ethernet Link Class]
+    Revision = 3;
+    MaxInst  = 2;
+    Number_Of_Static_Instances  = 2;
+    Max_Number_Of_Dynamic_Instances = 0;
+    Class_Attributes =                  $ [K] comma-separated multi-value list -- parser must skip cleanly
+        1,
+        2,
+        3,
+        6,
+        7;
+    Instance_Attributes =
+        1,
+        2,
+        3,
+        6,
+        7,
+        8,
+        10;
+    Class_Services    = 0x0E;           $ hex value in a to-be-ignored section
+    Instance_Services =
+        0x0E,
+        0x10;
+    InterfaceLabel1 = "Port 1";
+    InterfaceLabel2 = "Port 2";
+    InterfaceType1  = 2;
+    InterfaceType2  = 2;
+
+$ =============================================================================
+$  APPENDIX: offset validation (golden assertion reference)
+$  ---------------------------------------------------------------------------
+$  Assem100 (O2T, size=16):
+$    DO0          byte0  bit0  BOOL  -> W
+$    DO1          byte0  bit1  BOOL  -> W
+$    DO2          byte0  bit2  BOOL  -> W
+$    (pad 5 bits) byte0  bit3  -- no resource
+$    Output SINT  byte1        SINT  -> W
+$    Output INT   byte2        INT   (scale=0.1) -> W
+$    Output DINT  byte4        DINT  -> W
+$    Output REAL  byte8        REAL  -> W
+$    Output Mode  byte12       UINT  (enum 0..3) -> W
+$    Setpoint     byte14       INT   -> W  (Param24 O2T side; T2O side in Assem101)
+$
+$  Assem101 (T2O, size=34):
+$    Input LINT   byte0        LINT  -> R
+$    Input ULINT  byte8        ULINT -> R
+$    Input LREAL  byte16       LREAL -> R
+$    Input USINT  byte24       USINT -> R
+$    (pad 8 bits) byte25       -- no resource
+$    Input WORD   byte26       WORD  -> R
+$    Input DWORD  byte28       DWORD -> R
+$    Setpoint_T2O byte32       INT   -> R  (Param24 T2O side; O2T side in Assem100)
+$
+$  Assem110 (Config, size=13):
+$    RPI          byte0        UDINT
+$    Config Flags byte4        BYTE
+$    Config Mask  byte5        LWORD
+$
+$  Explicit (from Link Path, no offset):
+$    Param20 -> objClass=1    instID=1 attrID=7  STRING        (Device Tag / ProductName)
+$    Param21 -> objClass=0x67 instID=1 attrID=1  SHORT_STRING  (Short Label)
+$    Param22 -> objClass=1    instID=1 attrID=7  STRING        (ProductName)
+$    Param23 -> objClass=1    instID=1 attrID=6  UDINT         (SerialNumber)
+$
+$  Enum (DeviceCommand with resourceOperation.mappings):
+$    Param9/Enum9 -> "Output Mode" command -> {0:Idle, 1:Run, 2:Jog, 3:Home}
+$ =============================================================================


### PR DESCRIPTION
Add pkg/profileconv/eds, converting an EtherNet/IP EDS (Electronic Data Sheet) into an EdgeX DeviceProfile for the XRT EtherNet/IP device service. Convert satisfies profileconv.ConvertFunc, alongside other source formats.

Layered pipeline:
- parser:    EDS text -> semantics-free sections/entries/fields tree
- extractor: device identity, params, assemblies, connections; detects
             modular devices and safely skips their dynamic assemblies
- mapper:    implicit I/O, Settings, and explicit-messaging resources,
             with scaling (scale/base/offset/min/max/default), offset/bit
             math, name uniqueness, and hardened numeric limits
- convert:   orchestration; rejects no-convertible-content input and
             validates the full DeviceProfile struct

Bump go-mod-core-contracts to v4.1.0-dev.40. 