### PR TITLE
EDX-7226 Parse multiple statements packed on one EDS line

### DIFF
--- a/pkg/profileconv/eds/parser.go
+++ b/pkg/profileconv/eds/parser.go
@@ -159,7 +159,8 @@ func parse(r io.Reader) (*eds, errors.EdgeX) {
 
 // consumeLine processes one physical line: it rejects an unbalanced quote,
 // dispatches a section header, skips a blank line, or accumulates the line into
-// the current statement and flushes it on an unquoted ";".
+// the pending statement — splitting out any statements it completes once the
+// line contains an unquoted ";".
 func consumeLine(e *eds, cur **section, buf *strings.Builder, raw string, lineNo int) errors.EdgeX {
 	line := stripComment(raw) // "$" comment runs to end of line
 
@@ -194,10 +195,39 @@ func consumeLine(e *eds, cur **section, buf *strings.Builder, raw string, lineNo
 	if !hasSemicolon {
 		return nil
 	}
+	return splitStatements(cur, buf)
+}
 
-	stmt := strings.TrimSpace(buf.String())
+// splitStatements divides the accumulated buffer on unquoted ";" and adds each
+// complete statement, so a line packing several (e.g. "A = 1; B = 2;") yields
+// one entry per statement rather than merging them. Content after the last ";"
+// is a statement still awaiting its terminator; it is kept in buf to continue
+// accumulating on the next line.
+func splitStatements(cur **section, buf *strings.Builder) errors.EdgeX {
+	text := buf.String()
 	buf.Reset()
-	return addStatement(cur, stmt)
+
+	start := 0
+	inQuote := false
+	backslashes := 0
+	for i, r := range text {
+		switch {
+		case isUnescapedQuote(r, backslashes):
+			inQuote = !inQuote
+		case r == ';' && !inQuote:
+			if err := addStatement(cur, strings.TrimSpace(text[start:i])); err != nil {
+				return err
+			}
+			start = i + len(";")
+		}
+		backslashes = runBackslashes(backslashes, r)
+	}
+	// Keep any post-";" remainder to continue on the next physical line.
+	if rest := strings.TrimSpace(text[start:]); rest != "" {
+		buf.WriteString(rest)
+		buf.WriteString(" ")
+	}
+	return nil
 }
 
 // handleSectionHeader consumes trimmed if it is a "[...]" section header,

--- a/pkg/profileconv/eds/parser_test.go
+++ b/pkg/profileconv/eds/parser_test.go
@@ -205,6 +205,67 @@ func TestParseSemicolonInsideQuotesNotTerminator(t *testing.T) {
 	assertDeviceAFields(t, src, []string{"desc; more", "42", "99"})
 }
 
+// A physical line may pack several ";"-terminated statements; each becomes its
+// own entry rather than being merged into the first statement's last field. A
+// statement whose ";" comes on a later line still accumulates across the break.
+func TestParseMultipleStatementsPerLine(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want [][]string // per entry: keyword followed by its fields
+	}{
+		{"two on one line", "[Device]\n    A = 1; B = 2;\n",
+			[][]string{{"A", "1"}, {"B", "2"}}},
+		{"three on one line", "[Device]\n    A = 1; B = 2; C = 3;\n",
+			[][]string{{"A", "1"}, {"B", "2"}, {"C", "3"}}},
+		{"second statement spans lines", "[Device]\n    A = 1; B =\n        2;\n",
+			[][]string{{"A", "1"}, {"B", "2"}}},
+		{"third statement spans lines", "[Device]\n    A = 1; B = 2; C =\n        3;\n",
+			[][]string{{"A", "1"}, {"B", "2"}, {"C", "3"}}},
+		{"empty statement between separators", "[Device]\n    A = 1;; B = 2;\n",
+			[][]string{{"A", "1"}, {"B", "2"}}},
+		{"semicolon inside quotes is not a split", "[Device]\n    A = \"x; y\";\n",
+			[][]string{{"A", "x; y"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, err := parse(strings.NewReader(tt.src))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			assertParsedEntries(t, e.section(sectionDevice).entries, tt.want)
+		})
+	}
+}
+
+// assertParsedEntries checks that entries match want, where each want row is a
+// keyword followed by its expected fields.
+func assertParsedEntries(t *testing.T, entries []*entry, want [][]string) {
+	t.Helper()
+	if len(entries) != len(want) {
+		t.Fatalf("entries: got %d, want %d", len(entries), len(want))
+	}
+	for i, w := range want {
+		assertEntry(t, i, entries[i], w[0], w[1:])
+	}
+}
+
+// assertEntry checks one entry's keyword and fields.
+func assertEntry(t *testing.T, i int, en *entry, keyword string, fields []string) {
+	t.Helper()
+	if en.keyword != keyword {
+		t.Errorf("entry %d keyword: got %q, want %q", i, en.keyword, keyword)
+	}
+	if len(en.fields) != len(fields) {
+		t.Fatalf("entry %d fields: got %q, want %q", i, en.fields, fields)
+	}
+	for j := range fields {
+		if en.fields[j] != fields[j] {
+			t.Errorf("entry %d field %d: got %q, want %q", i, j, en.fields[j], fields[j])
+		}
+	}
+}
+
 // Regression: a statement not terminated by ";" before EOF must be
 // reported, not silently dropped.
 func TestParseUnterminatedStatementAtEOFErrors(t *testing.T) {


### PR DESCRIPTION
## What

A physical EDS line may hold several `;`-terminated statements (e.g. `A = 1; B = 2;`). The parser previously flushed the whole buffer as one statement on the first `;`, silently merging the rest into that statement's last field and dropping the later entries.

## Change

- `splitStatements` divides the accumulated buffer on unquoted `;`, adding one entry per complete statement.
- Content after the last `;` stays buffered to continue on the next line, so a statement whose terminator lands on a later line still accumulates correctly.
- A `;` inside a quoted string is not a split point (existing escape/quote logic reused).

## Tests

`TestParseMultipleStatementsPerLine` covers: same-line pair, three-on-one-line, second/third statement spanning lines, empty slot between separators (`A=1;; B=2;`), and in-quote `;`.

Full `make test` passes; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)